### PR TITLE
fix(python): raise build/runtime dependency floors

### DIFF
--- a/sdks/python/API_REFERENCE.md
+++ b/sdks/python/API_REFERENCE.md
@@ -1456,7 +1456,7 @@ title: str # The market title (e.g., "Will BTC close above $100k on Dec 31?").
 description: str # Long-form market description or resolution criteria.
 slug: str # URL-friendly slug for the market.
 outcomes: List[MarketOutcome] # The possible outcomes for this market.
-resolution_date: str # When the market is scheduled to resolve.
+resolution_date: str # When the market is scheduled to resolve. Optional because some venues do not publish a cutoff for every market (e.g. Opinion categorical children) — emit `undefined` rather than coercing to epoch.
 volume24h: float # Trading volume over the past 24 hours (USD).
 volume: float # Total / Lifetime volume
 liquidity: float # Current market liquidity (USD).

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "urllib3>=1.26.0",
+    "urllib3>=2.7.0",
     "python-dateutil>=2.8.0",
     "pydantic>=2.0.0",
     "typing-extensions>=4.0.0",

--- a/sdks/typescript/API_REFERENCE.md
+++ b/sdks/typescript/API_REFERENCE.md
@@ -1456,7 +1456,7 @@ title: string; // The market title (e.g., "Will BTC close above $100k on Dec 31?
 description: string; // Long-form market description or resolution criteria.
 slug: string; // URL-friendly slug for the market.
 outcomes: MarketOutcome[]; // The possible outcomes for this market.
-resolutionDate: string; // When the market is scheduled to resolve.
+resolutionDate: string; // When the market is scheduled to resolve. Optional because some venues do not publish a cutoff for every market (e.g. Opinion categorical children) — emit `undefined` rather than coercing to epoch.
 volume24h: number; // Trading volume over the past 24 hours (USD).
 volume: number; // Total / Lifetime volume
 liquidity: number; // Current market liquidity (USD).


### PR DESCRIPTION
## Summary
- Raises the Python SDK build-system floor for setuptools and wheel.
- Raises the runtime urllib3 floor to a fixed release.

## Verification
- Parsed sdks/python/pyproject.toml with tomllib after the edit.

Fixes #824
Fixes #828
Fixes #829