### PR TITLE
fix(python): guard nullable market slug cache

### DIFF
--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -763,7 +763,8 @@ class Exchange(ABC):
 
         for market in markets:
             self.markets[market.market_id] = market
-            self.markets_by_slug[market.slug] = market
+            if market.slug:
+                self.markets_by_slug[market.slug] = market
 
         self._loaded_markets = True
         return self.markets


### PR DESCRIPTION
## Summary
- Skip slug index entries when a loaded market has no slug
- Mirrors the TypeScript loadMarkets guard and prevents crashes on slugless venues

Fixes #156

## Test Plan
- [x] git diff --check
- [x] python3 -m py_compile sdks/python/pmxt/client.py