### PR TITLE
fix: log code hygiene failures

### DIFF
--- a/core/src/exchanges/baozi/fetcher.ts
+++ b/core/src/exchanges/baozi/fetcher.ts
@@ -158,7 +158,8 @@ export class BaoziFetcher implements IExchangeFetcher<BaoziRawMarket, BaoziRawMa
             }
 
             return null;
-        } catch {
+        } catch (err) {
+            logger.warn('BaoziFetcher: fetchRawSingleMarket failed', { pubkey, error: String(err) });
             return null;
         }
     }

--- a/core/src/exchanges/myriad/fetcher.ts
+++ b/core/src/exchanges/myriad/fetcher.ts
@@ -2,6 +2,7 @@ import { MarketFilterParams, EventFetchParams, OHLCVParams, TradesParams, MyTrad
 import { IExchangeFetcher, FetcherContext } from '../interfaces';
 import { DEFAULT_BASE_URL, mapStatusToMyriad } from './utils';
 import { myriadErrorMapper } from './errors';
+import { logger } from '../../utils/logger';
 
 const MAX_PAGE_SIZE = 100;
 
@@ -200,7 +201,8 @@ export class MyriadFetcher implements IExchangeFetcher<MyriadRawMarket, MyriadRa
             const data = response.data;
             if (data.error) return null;
             return { bids: data.bids || [], asks: data.asks || [] };
-        } catch {
+        } catch (err) {
+            logger.warn('MyriadFetcher: fetchClobOrderBook failed', { marketId, error: String(err) });
             return null;
         }
     }

--- a/core/src/exchanges/polymarket/auth.ts
+++ b/core/src/exchanges/polymarket/auth.ts
@@ -104,7 +104,6 @@ export class PolymarketAuth {
         let creds: ApiKeyCreds | undefined;
 
         try {
-            // console.log('Trying to derive existing API key...');
             creds = await l1Client.deriveApiKey();
             if (!creds || !creds.key || !creds.secret || !creds.passphrase) {
                 // If derived creds are missing, throw to trigger catch -> create
@@ -124,7 +123,6 @@ export class PolymarketAuth {
             throw new Error('Authentication failed: Derived credentials are incomplete.');
         }
 
-        // console.log(`[PolymarketAuth] Successfully obtained API credentials for key ${creds.key.substring(0, 8)}...`);
         this.apiCreds = creds;
         return creds;
     }
@@ -153,8 +151,6 @@ export class PolymarketAuth {
                 timeout: 10_000,
             });
             const profile = response.data;
-            // console.log(`[PolymarketAuth] Profile for ${address}:`, JSON.stringify(profile));
-
             if (profile && profile.proxyAddress) {
                 this.discoveredProxyAddress = profile.proxyAddress;
                 // Determine signature type. 
@@ -162,7 +158,6 @@ export class PolymarketAuth {
                 // If it's a proxy address but we don't know the type, 1 is a safe default for Polymarket.
                 this.discoveredSignatureType = profile.isGnosisSafe ? SIG_TYPE_GNOSIS_SAFE : SIG_TYPE_POLY_PROXY;
 
-                // console.log(`[PolymarketAuth] Auto-discovered proxy for ${address}: ${this.discoveredProxyAddress} (Type: ${this.discoveredSignatureType})`);
                 if (!this.discoveredProxyAddress || this.discoveredSignatureType === undefined) {
                     throw new Error('[polymarket] Proxy discovery incomplete — missing proxyAddress or signatureType');
                 }
@@ -274,8 +269,6 @@ export class PolymarketAuth {
         const finalSignatureType: number = signatureType;
 
         // Create L2-authenticated client
-        // console.log(`[PolymarketAuth] Initializing ClobClient | Signer: ${signerAddress} | Funder: ${finalProxyAddress} | SigType: ${finalSignatureType}`);
-
         this.clobClient = new ClobClient({
             host: this.host,
             chain: POLYMARKET_CHAIN_ID,

--- a/core/src/router/e2e-orderbook.ts
+++ b/core/src/router/e2e-orderbook.ts
@@ -7,11 +7,12 @@
 import { Router } from './Router';
 import { PolymarketExchange } from '../exchanges/polymarket';
 import { LimitlessExchange } from '../exchanges/limitless';
+import { logger } from '../utils/logger';
 
 async function main() {
     const apiKey = process.env.PMXT_API_KEY;
     if (!apiKey) {
-        console.error('Set PMXT_API_KEY');
+        logger.error('Set PMXT_API_KEY');
         process.exit(1);
     }
 
@@ -26,16 +27,16 @@ async function main() {
     // Morocco FIFA World Cup market on Polymarket
     const marketId = 'f017596d-4d53-49d5-a7d6-36ed9c37fdc4';
 
-    console.log('Fetching unified orderbook for Morocco (Polymarket + Limitless)...');
-    console.log(`Input market ID: ${marketId}`);
-    console.log('---');
+    logger.info('Fetching unified orderbook for Morocco (Polymarket + Limitless)...');
+    logger.info(`Input market ID: ${marketId}`);
+    logger.info('---');
 
     const book = await router.fetchOrderBook(marketId, undefined, { side: 'yes' });
 
-    console.log(`Bids: ${book.bids.length} levels`);
-    console.log(`Asks: ${book.asks.length} levels`);
-    console.log('Top 5 bids:', book.bids.slice(0, 5));
-    console.log('Top 5 asks:', book.asks.slice(0, 5));
+    logger.info(`Bids: ${book.bids.length} levels`);
+    logger.info(`Asks: ${book.asks.length} levels`);
+    logger.info('Top 5 bids:', { bids: book.bids.slice(0, 5) });
+    logger.info('Top 5 asks:', { asks: book.asks.slice(0, 5) });
 
     // Verify we got data from BOTH exchanges
     // Polymarket top bid was 0.016, Limitless had 0.002
@@ -43,22 +44,22 @@ async function main() {
     const hasPoly = book.bids.some((b) => b.price === 0.016);
     const hasLimitless = book.bids.some((b) => b.price === 0.002);
 
-    console.log('---');
-    console.log(`Has Polymarket levels: ${hasPoly}`);
-    console.log(`Has Limitless levels: ${hasLimitless}`);
+    logger.info('---');
+    logger.info(`Has Polymarket levels: ${hasPoly}`);
+    logger.info(`Has Limitless levels: ${hasLimitless}`);
 
     if (hasPoly && hasLimitless) {
-        console.log('SUCCESS: Merged orderbook contains levels from both exchanges');
+        logger.info('SUCCESS: Merged orderbook contains levels from both exchanges');
     } else if (!hasPoly && hasLimitless) {
-        console.log('PARTIAL: Only Limitless book (source market fetch failed)');
+        logger.info('PARTIAL: Only Limitless book (source market fetch failed)');
     } else if (hasPoly && !hasLimitless) {
-        console.log('PARTIAL: Only Polymarket book (matched market fetch failed)');
+        logger.info('PARTIAL: Only Polymarket book (matched market fetch failed)');
     } else {
-        console.log('FAIL: No data from either exchange');
+        logger.info('FAIL: No data from either exchange');
     }
 }
 
 main().catch((err) => {
-    console.error(err);
+    logger.error('E2E orderbook script failed', { error: String(err) });
     process.exit(1);
 });

--- a/core/src/server/utils/lock-file.ts
+++ b/core/src/server/utils/lock-file.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { execSync } from 'child_process';
+import { logger } from '../../utils/logger';
 
 export class LockFile {
     public lockPath: string;
@@ -31,8 +32,10 @@ export class LockFile {
     async remove(): Promise<void> {
         try {
             await fs.unlink(this.lockPath);
-        } catch {
-            // Ignore errors if file doesn't exist
+        } catch (err: any) {
+            if (err?.code !== 'ENOENT') {
+                logger.warn('LockFile: failed to remove lock', { path: this.lockPath, error: String(err) });
+            }
         }
     }
 

--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -53,6 +53,7 @@ import { buildArgsWithOptionalOptions } from "./args.js";
 import { PmxtError, fromServerError } from "./errors.js";
 import { LOCAL_URL, resolvePmxtBaseUrl } from "./constants.js";
 import { SidecarWsClient } from "./ws-client.js";
+import { logger } from "./logger.js";
 
 interface RawWebSocketLike {
     send(data: string): void;
@@ -430,8 +431,8 @@ export abstract class Exchange {
                 if (attempt === 0 && !this.isHosted) {
                     try {
                         await this.serverManager.ensureServerRunning();
-                    } catch {
-                        // Restart failed — continue retrying anyway
+                    } catch (err) {
+                        logger.warn('PmxtClient: server restart failed during retry', { attempt, error: String(err) });
                     }
                 }
                 await new Promise(resolve => setTimeout(resolve, delays[attempt]));
@@ -477,7 +478,8 @@ export abstract class Exchange {
             if (!client.connected) {
                 throw new Error("WS handshake failed");
             }
-        } catch {
+        } catch (err) {
+            logger.warn('PmxtClient: WebSocket probe failed, falling back to HTTP', { error: String(err) });
             this._wsUnsupported = true;
             client.close();
             return null;
@@ -2014,7 +2016,10 @@ export abstract class Exchange {
                         const body = await res.json();
                         this._hostedAccount = { depositWallet: body.deposit_wallet, signatureType: body.signature_type };
                     } else { this._hostedAccount = {}; }
-                } catch { this._hostedAccount = {}; }
+                } catch (err) {
+                    logger.warn('PmxtClient: hosted account discovery failed', { error: String(err) });
+                    this._hostedAccount = {};
+                }
             })();
         }
         await this._accountDiscoveryPromise;

--- a/sdks/typescript/pmxt/server-manager.ts
+++ b/sdks/typescript/pmxt/server-manager.ts
@@ -8,6 +8,7 @@ import { DefaultApi, Configuration } from "../generated/src/index.js";
 import { readFileSync, existsSync } from "fs";
 import { homedir } from "os";
 import { join, dirname } from "path";
+import { logger } from "./logger.js";
 
 export interface ServerManagerOptions {
     baseUrl?: string;
@@ -145,8 +146,8 @@ export class ServerManager {
                         const data = await response.json() as any;
                         if (data.status === "ok") return;
                     }
-                } catch {
-                    // Not ready yet
+                } catch (err) {
+                    logger.debug('server-manager: health poll error', { error: String(err) });
                 }
             }
             await new Promise((resolve) => setTimeout(resolve, this.retryDelayMs));
@@ -264,8 +265,8 @@ export class ServerManager {
                     return true;
                 }
             }
-        } catch {
-            // Ignore errors
+        } catch (err) {
+            logger.warn('server-manager: version check failed', { error: String(err) });
         }
         return false;
     }
@@ -385,6 +386,9 @@ export class ServerManager {
         try {
             const { unlinkSync } = await import('fs');
             unlinkSync(this.lockPath);
-        } catch { }
+        } catch (err) {
+            // Best-effort — expected when file was already removed.
+            logger.debug('server-manager: lock file removal failed', { path: this.lockPath, error: String(err) });
+        }
     }
 }

--- a/sdks/typescript/pmxt/ws-client.ts
+++ b/sdks/typescript/pmxt/ws-client.ts
@@ -343,8 +343,8 @@ export class SidecarWsClient {
         if (this.ws) {
             try {
                 this.ws.close();
-            } catch {
-                // ignore
+            } catch (err) {
+                logger.debug('[SidecarWsClient] error during ws.close()', { error: String(err) });
             }
             this.ws = null;
         }


### PR DESCRIPTION
## Summary
- Add structured logging to silent TypeScript SDK/server-manager/sidecar catches
- Narrow lock-file removal handling to ignore ENOENT only and log unexpected failures
- Replace production console calls in the router E2E script with the core logger
- Remove dead commented-out Polymarket debug console statements

Fixes #947
Fixes #946
Fixes #945
Fixes #944
Fixes #943
Fixes #942
Fixes #941
Fixes #940
Fixes #939
Fixes #938
Fixes #937
Fixes #808

## Test Plan
- git diff --check
- npm run build --workspace=pmxt-core (timed out after 300s after tsc/copy output; no TypeScript errors emitted before timeout)
- npm run build --workspace=pmxtjs (fails: generated TypeScript client missing at sdks/typescript/generated/src/index.js in this checkout)
