### PR TITLE
fix: export Suibets alias in TypeScript SDK

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -19,14 +19,14 @@
  */
 
 
-import { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Mock } from "./pmxt/client.js";
+import { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Suibets, Mock } from "./pmxt/client.js";
 import { Router } from "./pmxt/router.js";
 import { ServerManager } from "./pmxt/server-manager.js";
 import { FeedClient } from "./pmxt/feed-client.js";
 import * as models from "./pmxt/models.js";
 import * as errors from "./pmxt/errors.js";
 
-export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Mock, PolymarketOptions } from "./pmxt/client.js";
+export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Suibets, Mock, PolymarketOptions } from "./pmxt/client.js";
 export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
 export { Router } from "./pmxt/router.js";
@@ -87,6 +87,7 @@ const pmxt = {
     GeminiTitan,
     Hyperliquid,
     SuiBets,
+    Suibets,
     Mock,
     Router,
     ServerManager,

--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -2874,6 +2874,9 @@ export class SuiBets extends Exchange {
     }
 }
 
+// Backwards-compatible casing alias matching the Python SDK export.
+export const Suibets = SuiBets;
+
 /**
  * Mock exchange client.
  *


### PR DESCRIPTION
## Summary
- Add a TypeScript `Suibets` export alias for `SuiBets`
- Include the alias in the package root exports and default export object

Fixes #885

## Test Plan
- git diff --check
- npm run build --workspace=pmxtjs (not rerun here; generated TypeScript client is absent in this checkout and the same command fails before this change on ../generated/src/index.js)
