### PR TITLE
fix(core): handle shutdown lock cleanup rejection

### DIFF
--- a/core/src/server/index.ts
+++ b/core/src/server/index.ts
@@ -60,11 +60,20 @@ async function main() {
     logger.info(`Lock file created at ${lockFile.lockPath}`);
 
     // Graceful shutdown
-    const shutdown = async () => {
+    let shuttingDown = false;
+    const shutdown = () => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+
         logger.info('Shutting down gracefully...');
         server.close();
-        await lockFile.remove();
-        process.exit(0);
+        void lockFile.remove()
+            .catch((error) => {
+                logger.warn('Failed to remove lock file during shutdown:', error);
+            })
+            .finally(() => {
+                process.exit(0);
+            });
     };
 
     process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- make signal shutdown handler synchronous so Node does not ignore a returned rejecting Promise
- catch lock-file cleanup failures, log them, and still exit with the intended success code
- guard against duplicate SIGTERM/SIGINT shutdown execution

Fixes #720

## Test Plan
- npm run build --workspace=pmxt-core