### PR TITLE
fix(core): support Opinion code/msg envelopes

### DIFF
--- a/core/src/exchanges/opinion/fetcher.ts
+++ b/core/src/exchanges/opinion/fetcher.ts
@@ -180,8 +180,10 @@ export interface OpinionRawOrder {
 // ----------------------------------------------------------------------------
 
 interface OpinionApiResponse<T> {
-    errno: number;
-    errmsg: string;
+    code?: number;
+    msg?: string;
+    errno?: number;
+    errmsg?: string;
     result: T;
 }
 
@@ -589,9 +591,10 @@ export class OpinionFetcher implements IExchangeFetcher<OpinionRawMarket, Opinio
      * Validates that the API response envelope indicates success (code === 0).
      */
     private assertSuccess(data: OpinionApiResponse<any>): void {
-        if (data.errno !== 0) {
+        const code = data.code ?? data.errno;
+        if (code !== 0) {
             throw new Error(
-                `Opinion API error (errno ${data.errno}): ${data.errmsg || 'Unknown error'}`,
+                `Opinion API error (code ${code ?? 'unknown'}): ${data.msg || data.errmsg || 'Unknown error'}`,
             );
         }
     }

--- a/core/src/exchanges/opinion/index.ts
+++ b/core/src/exchanges/opinion/index.ts
@@ -397,9 +397,11 @@ export class OpinionExchange extends PredictionMarketExchange {
             const client = await auth.getClobClient();
             const response = await client.placeOrder(built.raw);
 
-            if (response.errno !== 0) {
+            const errorCode = response.code ?? response.errno;
+            const errorMessage = response.msg || response.errmsg || 'Unknown error';
+            if (errorCode !== 0) {
                 throw new Error(
-                    `Order submission failed: ${response.errmsg} (errno: ${response.errno})`,
+                    `Order submission failed: ${errorMessage} (code: ${errorCode ?? 'unknown'})`,
                 );
             }
 
@@ -437,9 +439,11 @@ export class OpinionExchange extends PredictionMarketExchange {
 
             const response = await client.cancelOrder(orderId);
 
-            if (response.errno !== 0) {
+            const errorCode = response.code ?? response.errno;
+            const errorMessage = response.msg || response.errmsg || 'Unknown error';
+            if (errorCode !== 0) {
                 throw new Error(
-                    `Order cancellation failed: ${response.errmsg} (errno: ${response.errno})`,
+                    `Order cancellation failed: ${errorMessage} (code: ${errorCode ?? 'unknown'})`,
                 );
             }
 

--- a/core/test/exchanges/opinion-fetcher-envelope.test.ts
+++ b/core/test/exchanges/opinion-fetcher-envelope.test.ts
@@ -1,0 +1,46 @@
+import { OpinionFetcher } from '../../src/exchanges/opinion/fetcher';
+import { FetcherContext } from '../../src/exchanges/interfaces';
+
+function makeFetcher(data: unknown) {
+    const get = jest.fn(async () => ({ data }));
+    const ctx: FetcherContext = {
+        http: { get } as any,
+        callApi: jest.fn() as any,
+        getHeaders: jest.fn(() => ({ Authorization: 'Bearer test' })),
+    };
+    return new OpinionFetcher(ctx, 'https://api.opinion.test');
+}
+
+describe('OpinionFetcher response envelopes', () => {
+    it('accepts documented code/msg success envelopes', async () => {
+        const rawMarket = { id: 42, question: 'Will it work?' } as any;
+        const fetcher = makeFetcher({
+            code: 0,
+            msg: 'success',
+            result: { data: rawMarket },
+        });
+
+        await expect(fetcher.fetchRawMarketById(42)).resolves.toBe(rawMarket);
+    });
+
+    it('rejects documented code/msg error envelopes', async () => {
+        const fetcher = makeFetcher({
+            code: 123,
+            msg: 'bad request',
+            result: null,
+        });
+
+        await expect(fetcher.fetchRawMarketById(42)).rejects.toThrow('Opinion API error (code 123): bad request');
+    });
+
+    it('continues to accept legacy errno/errmsg envelopes', async () => {
+        const rawMarket = { id: 43, question: 'Legacy?' } as any;
+        const fetcher = makeFetcher({
+            errno: 0,
+            errmsg: 'success',
+            result: { data: rawMarket },
+        });
+
+        await expect(fetcher.fetchRawMarketById(43)).resolves.toBe(rawMarket);
+    });
+});


### PR DESCRIPTION
## Summary
- Accept Opinion REST envelopes using documented `code`/`msg` fields while preserving legacy `errno`/`errmsg` compatibility.
- Apply the same error-code normalization to Opinion order submission and cancellation responses.
- Add targeted fetcher tests for documented success/error envelopes and legacy compatibility.

Fixes #416

## Test Plan
- `npm test --workspace=pmxt-core -- --runTestsByPath test/exchanges/opinion-fetcher-envelope.test.ts --runInBand`