### PR TITLE
feat(core): openapi schema for hosted-mode enrichment fields (v2.49.1)

### DIFF
--- a/core/scripts/generate-openapi.js
+++ b/core/scripts/generate-openapi.js
@@ -1047,13 +1047,36 @@ function typeNodeToSchema(node, sourceFile) {
 
     case ts.SyntaxKind.UnionType: {
       const members = node.types;
+      // Track whether the union includes `null` (an explicit `null` member
+      // means the field is nullable on the wire even if also `?:` optional).
+      // We strip `null` / `undefined` before classifying the union shape,
+      // then re-apply `nullable: true` to the resulting schema so the JSON
+      // shape stays a single type rather than a `oneOf [T, null]`.
+      // TS parses `null` inside a union as `LiteralType` wrapping
+      // `NullKeyword` (not bare `NullKeyword`), so check both forms.
+      const isNullMember = (t) =>
+        t.kind === ts.SyntaxKind.NullKeyword ||
+        (t.kind === ts.SyntaxKind.LiteralType &&
+          t.literal &&
+          t.literal.kind === ts.SyntaxKind.NullKeyword);
+      const isUndefinedMember = (t) =>
+        t.kind === ts.SyntaxKind.UndefinedKeyword;
+      const includesNull = members.some(isNullMember);
       const nonNull = members.filter(
-        t =>
-          t.kind !== ts.SyntaxKind.NullKeyword &&
-          t.kind !== ts.SyntaxKind.UndefinedKeyword
+        t => !isNullMember(t) && !isUndefinedMember(t)
       );
 
       if (nonNull.length === 0) return null;
+
+      const withNullable = (schema) => {
+        if (!includesNull || !schema) return schema;
+        // OpenAPI 3.0: nullable is a sibling keyword on the schema itself.
+        // For $ref values we wrap in allOf so nullable doesn't get dropped.
+        if (schema.$ref) {
+          return { allOf: [schema], nullable: true };
+        }
+        return { ...schema, nullable: true };
+      };
 
       // All string literals → enum
       if (
@@ -1063,17 +1086,22 @@ function typeNodeToSchema(node, sourceFile) {
             t.literal.kind === ts.SyntaxKind.StringLiteral
         )
       ) {
-        return { type: 'string', enum: nonNull.map(t => t.literal.text) };
+        return withNullable({
+          type: 'string',
+          enum: nonNull.map(t => t.literal.text),
+        });
       }
 
-      if (nonNull.length === 1) return typeNodeToSchema(nonNull[0], sourceFile);
+      if (nonNull.length === 1) {
+        return withNullable(typeNodeToSchema(nonNull[0], sourceFile));
+      }
 
       const schemas = nonNull
         .map(t => typeNodeToSchema(t, sourceFile))
         .filter(s => s !== null);
       if (schemas.length === 0) return null;
-      if (schemas.length === 1) return schemas[0];
-      return { oneOf: schemas };
+      if (schemas.length === 1) return withNullable(schemas[0]);
+      return withNullable({ oneOf: schemas });
     }
 
     case ts.SyntaxKind.LiteralType: {
@@ -1664,8 +1692,129 @@ const STATIC_SCHEMAS = {
   },
   ErrorDetail: {
     type: 'object',
+    description:
+      'Structured error envelope returned inside `BaseResponse.error` and `ErrorResponse.error`. ' +
+      'Hosted-mode endpoints populate `code`, `retryable`, and optionally `exchange` / `detail`; ' +
+      'legacy local-mode endpoints may still return only `message`.',
     properties: {
-      message: { type: 'string' },
+      message: {
+        type: 'string',
+        description: 'Human-readable error message.',
+      },
+      code: {
+        type: 'string',
+        description:
+          'Stable machine-readable error code. Hosted-mode errors use the `HostedTradingError` family ' +
+          '(e.g. `INSUFFICIENT_ESCROW_BALANCE`, `BUILT_ORDER_EXPIRED`); pre-hosted local errors use the ' +
+          'legacy family (e.g. `BAD_REQUEST`, `NOT_FOUND`).',
+        enum: [
+          // Hosted-mode error codes (v2.49.0+)
+          'HOSTED_TRADING_ERROR',
+          'INSUFFICIENT_ESCROW_BALANCE',
+          'ORDER_SIZE_TOO_SMALL',
+          'INVALID_API_KEY',
+          'OUTCOME_NOT_FOUND',
+          'CATALOG_UNAVAILABLE',
+          'BUILT_ORDER_EXPIRED',
+          'INVALID_SIGNATURE',
+          'NO_LIQUIDITY',
+          'MISSING_WALLET_ADDRESS',
+          // Pre-hosted (legacy) error codes
+          'BAD_REQUEST',
+          'AUTHENTICATION_ERROR',
+          'PERMISSION_DENIED',
+          'NOT_FOUND',
+          'ORDER_NOT_FOUND',
+          'MARKET_NOT_FOUND',
+          'EVENT_NOT_FOUND',
+          'RATE_LIMIT_EXCEEDED',
+          'INVALID_ORDER',
+          'INSUFFICIENT_FUNDS',
+          'VALIDATION_ERROR',
+          'NETWORK_ERROR',
+          'EXCHANGE_NOT_AVAILABLE',
+          'NOT_SUPPORTED',
+        ],
+      },
+      retryable: {
+        type: 'boolean',
+        description:
+          'Hint for clients: when `true`, the same request may succeed on retry (e.g. transient network ' +
+          'or rate-limit conditions); when `false`, the caller should not retry without modifying the ' +
+          'request.',
+      },
+      exchange: {
+        type: 'string',
+        nullable: true,
+        description:
+          "Venue the error originated from, when known (e.g. 'polymarket', 'kalshi').",
+      },
+      detail: {
+        type: 'object',
+        additionalProperties: {},
+        nullable: true,
+        description:
+          'Free-form hosted-mode detail blob. Shape depends on `code` — e.g. for ' +
+          '`INSUFFICIENT_ESCROW_BALANCE` it may include `{ requested, available }`; for ' +
+          '`ORDER_SIZE_TOO_SMALL` it may include `{ min }`; for `BUILT_ORDER_EXPIRED` it may include ' +
+          '`{ expiry }`.',
+      },
+    },
+  },
+  ExchangeOptions: {
+    type: 'object',
+    description:
+      'Constructor-level options for venue clients (Polymarket, Kalshi, Opinion, etc.).\n' +
+      'Hosted mode is the default when pmxtApiKey is set; otherwise the SDK runs against\n' +
+      'a local sidecar with venue credentials.',
+    properties: {
+      pmxtApiKey: {
+        type: 'string',
+        description:
+          'PMXT customer API key. When set, the SDK routes to api.pmxt.dev (catalog) and ' +
+          'trade.pmxt.dev (trading). Get one at pmxt.dev/dashboard.',
+      },
+      walletAddress: {
+        type: 'string',
+        nullable: true,
+        description:
+          'EVM wallet address for hosted reads/writes. Required for endpoints that operate on a wallet ' +
+          '(balances, positions, trades, open orders).',
+      },
+      signer: {
+        type: 'object',
+        nullable: true,
+        description:
+          'Optional pre-built signer for hosted writes. If absent and privateKey is set, the SDK ' +
+          'auto-wraps privateKey into a signer.',
+      },
+      privateKey: {
+        type: 'string',
+        nullable: true,
+        description:
+          'Private key. In hosted mode, used to derive an EIP-712 signer for writes (wraps into ' +
+          'EthAccountSigner/EthersSigner). In self-hosted mode, used as the venue credential directly.',
+      },
+      baseUrl: {
+        type: 'string',
+        nullable: true,
+        description:
+          'Explicit base URL override. When unset, the SDK uses api.pmxt.dev when pmxtApiKey is set, ' +
+          'or the local sidecar otherwise.',
+      },
+      apiKey: {
+        type: 'string',
+        nullable: true,
+        description:
+          'Venue-side API key (e.g. Polymarket CLOB key). Only relevant for self-hosted mode.',
+      },
+      autoStartServer: {
+        type: 'boolean',
+        nullable: true,
+        description:
+          'Auto-start the local sidecar when running self-hosted. Defaults to true when no pmxtApiKey ' +
+          'is set, false when hosted.',
+      },
     },
   },
   BaseRequest: {

--- a/core/src/exchanges/mock/index.ts
+++ b/core/src/exchanges/mock/index.ts
@@ -463,7 +463,11 @@ export class MockExchange extends PredictionMarketExchange {
         const outcome = market?.outcomes.find(o => o.outcomeId === params.outcomeId);
 
         if (existing) {
-            const epx = existing.entryPrice * existing.size;
+            // entryPrice became nullable in v2.49 for hosted-mode positions,
+            // but the mock exchange always populates it on first fill — fall
+            // back to the new fill price if a prior fill somehow left it unset.
+            const prevEntry = existing.entryPrice ?? price;
+            const epx = prevEntry * existing.size;
             const npx = price * sizeDelta;
             const newEntry = (epx + npx) / newSize;
             const ep = round(newEntry, 4);

--- a/core/src/server/openapi.yaml
+++ b/core/src/server/openapi.yaml
@@ -2872,9 +2872,108 @@ components:
           $ref: '#/components/schemas/ErrorDetail'
     ErrorDetail:
       type: object
+      description: >-
+        Structured error envelope returned inside `BaseResponse.error` and `ErrorResponse.error`. Hosted-mode endpoints
+        populate `code`, `retryable`, and optionally `exchange` / `detail`; legacy local-mode endpoints may still return
+        only `message`.
       properties:
         message:
           type: string
+          description: Human-readable error message.
+        code:
+          type: string
+          description: >-
+            Stable machine-readable error code. Hosted-mode errors use the `HostedTradingError` family (e.g.
+            `INSUFFICIENT_ESCROW_BALANCE`, `BUILT_ORDER_EXPIRED`); pre-hosted local errors use the legacy family (e.g.
+            `BAD_REQUEST`, `NOT_FOUND`).
+          enum:
+            - HOSTED_TRADING_ERROR
+            - INSUFFICIENT_ESCROW_BALANCE
+            - ORDER_SIZE_TOO_SMALL
+            - INVALID_API_KEY
+            - OUTCOME_NOT_FOUND
+            - CATALOG_UNAVAILABLE
+            - BUILT_ORDER_EXPIRED
+            - INVALID_SIGNATURE
+            - NO_LIQUIDITY
+            - MISSING_WALLET_ADDRESS
+            - BAD_REQUEST
+            - AUTHENTICATION_ERROR
+            - PERMISSION_DENIED
+            - NOT_FOUND
+            - ORDER_NOT_FOUND
+            - MARKET_NOT_FOUND
+            - EVENT_NOT_FOUND
+            - RATE_LIMIT_EXCEEDED
+            - INVALID_ORDER
+            - INSUFFICIENT_FUNDS
+            - VALIDATION_ERROR
+            - NETWORK_ERROR
+            - EXCHANGE_NOT_AVAILABLE
+            - NOT_SUPPORTED
+        retryable:
+          type: boolean
+          description: >-
+            Hint for clients: when `true`, the same request may succeed on retry (e.g. transient network or rate-limit
+            conditions); when `false`, the caller should not retry without modifying the request.
+        exchange:
+          type: string
+          nullable: true
+          description: 'Venue the error originated from, when known (e.g. ''polymarket'', ''kalshi'').'
+        detail:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: >-
+            Free-form hosted-mode detail blob. Shape depends on `code` — e.g. for `INSUFFICIENT_ESCROW_BALANCE` it may
+            include `{ requested, available }`; for `ORDER_SIZE_TOO_SMALL` it may include `{ min }`; for
+            `BUILT_ORDER_EXPIRED` it may include `{ expiry }`.
+    ExchangeOptions:
+      type: object
+      description: |-
+        Constructor-level options for venue clients (Polymarket, Kalshi, Opinion, etc.).
+        Hosted mode is the default when pmxtApiKey is set; otherwise the SDK runs against
+        a local sidecar with venue credentials.
+      properties:
+        pmxtApiKey:
+          type: string
+          description: >-
+            PMXT customer API key. When set, the SDK routes to api.pmxt.dev (catalog) and trade.pmxt.dev (trading). Get
+            one at pmxt.dev/dashboard.
+        walletAddress:
+          type: string
+          nullable: true
+          description: >-
+            EVM wallet address for hosted reads/writes. Required for endpoints that operate on a wallet (balances,
+            positions, trades, open orders).
+        signer:
+          type: object
+          nullable: true
+          description: >-
+            Optional pre-built signer for hosted writes. If absent and privateKey is set, the SDK auto-wraps privateKey
+            into a signer.
+        privateKey:
+          type: string
+          nullable: true
+          description: >-
+            Private key. In hosted mode, used to derive an EIP-712 signer for writes (wraps into
+            EthAccountSigner/EthersSigner). In self-hosted mode, used as the venue credential directly.
+        baseUrl:
+          type: string
+          nullable: true
+          description: >-
+            Explicit base URL override. When unset, the SDK uses api.pmxt.dev when pmxtApiKey is set, or the local
+            sidecar otherwise.
+        apiKey:
+          type: string
+          nullable: true
+          description: Venue-side API key (e.g. Polymarket CLOB key). Only relevant for self-hosted mode.
+        autoStartServer:
+          type: boolean
+          nullable: true
+          description: >-
+            Auto-start the local sidecar when running self-hosted. Defaults to true when no pmxtApiKey is set, false
+            when hosted.
     BaseRequest:
       type: object
       description: Base request structure with optional credentials
@@ -3107,14 +3206,12 @@ components:
           type: string
           description: 'Human-readable series title (e.g. "ATP Match Winner", "WTA").'
         description:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
           description: Long-form series description.
         recurrence:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
           description: 'Recurrence cadence the venue reports (''daily'', ''weekly'', ''annual'', ...).'
         events:
           type: array
@@ -3122,14 +3219,12 @@ components:
             $ref: '#/components/schemas/UnifiedEvent'
           description: Child events. Populated when fetched by id; the list form usually omits this to keep payloads small.
         url:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
           description: Canonical venue URL for the series.
         image:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
           description: Venue-hosted image.
         sourceExchange:
           type: string
@@ -3263,6 +3358,18 @@ components:
         orderId:
           type: string
           description: 'The order that produced this trade, if known.'
+        txHash:
+          type: string
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+        chain:
+          type: string
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+        blockNumber:
+          type: number
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
       required:
         - id
         - timestamp
@@ -3326,6 +3433,18 @@ components:
         feeRateBps:
           type: number
           description: Fee rate in basis points applied to this order (e.g. 100 = 1%).
+        txHash:
+          type: string
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+        chain:
+          type: string
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+        blockNumber:
+          type: number
+          nullable: true
+          description: Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
       required:
         - id
         - marketId
@@ -3339,6 +3458,10 @@ components:
         - timestamp
     Position:
       type: object
+      description: >-
+        A current position in a market. In hosted mode, `outcomeLabel`, `entryPrice`, `currentPrice` and `unrealizedPnL`
+        may be null when the server cannot derive them (e.g. `with_mtm=false` or no fill history). Venue-direct callers
+        continue to populate every field.
       properties:
         marketId:
           type: string
@@ -3348,30 +3471,58 @@ components:
           description: The outcome this position is held in.
         outcomeLabel:
           type: string
-          description: Human-readable label for the outcome held.
+          nullable: true
+          description: Human-readable label for the outcome held. Optional in hosted mode.
         size:
           type: number
           description: 'Positive for long, negative for short'
         entryPrice:
           type: number
-          description: Average entry price for the position (probability between 0.0 and 1.0).
+          nullable: true
+          description: >-
+            Average entry price for the position (probability between 0.0 and 1.0). Optional in hosted mode when no fill
+            history is available.
         currentPrice:
           type: number
-          description: Current mark price for the position (probability between 0.0 and 1.0).
+          nullable: true
+          description: >-
+            Current mark price for the position (probability between 0.0 and 1.0). Optional in hosted mode when
+            mark-to-market data is unavailable.
+        currentValue:
+          type: number
+          nullable: true
+          description: Current market value of the position (size * currentPrice). Null when currentPrice is unavailable.
         unrealizedPnL:
           type: number
-          description: Unrealized profit or loss at the current price (USD).
+          nullable: true
+          description: >-
+            Unrealized profit or loss at the current price (USD). Optional in hosted mode when mark-to-market data is
+            unavailable.
         realizedPnL:
           type: number
           description: Realized profit or loss booked so far (USD).
+        txHash:
+          type: string
+          nullable: true
+          description: >-
+            Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for
+            non-on-chain venues.
+        chain:
+          type: string
+          nullable: true
+          description: >-
+            Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for
+            non-on-chain venues.
+        blockNumber:
+          type: number
+          nullable: true
+          description: >-
+            Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for
+            non-on-chain venues.
       required:
         - marketId
         - outcomeId
-        - outcomeLabel
         - size
-        - entryPrice
-        - currentPrice
-        - unrealizedPnL
     Balance:
       type: object
       properties:
@@ -3387,6 +3538,12 @@ components:
         locked:
           type: number
           description: In open orders
+        venue:
+          type: string
+          nullable: true
+          description: >-
+            Hosted-mode: which venue this balance belongs to in a multi-venue response. Null when the balance is
+            venue-agnostic.
       required:
         - currency
         - total
@@ -3717,6 +3874,12 @@ components:
             populates this.
         raw:
           description: 'The raw, exchange-native payload. Always present.'
+        expiry:
+          type: number
+          nullable: true
+          description: >-
+            Unix epoch (ms) when this built order expires server-side. Submitting after expiry returns
+            BUILT_ORDER_EXPIRED.
       required:
         - exchange
         - params
@@ -4026,17 +4189,14 @@ components:
         confidence:
           type: number
         reasoning:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
         bestBid:
-          oneOf:
-            - type: number
-            - {}
+          type: number
+          nullable: true
         bestAsk:
-          oneOf:
-            - type: number
-            - {}
+          type: number
+          nullable: true
       required:
         - market
         - relation
@@ -4073,17 +4233,14 @@ components:
         confidence:
           type: number
         reasoning:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
         bestBid:
-          oneOf:
-            - type: number
-            - {}
+          type: number
+          nullable: true
         bestAsk:
-          oneOf:
-            - type: number
-            - {}
+          type: number
+          nullable: true
         venue:
           type: string
       required:
@@ -4184,9 +4341,8 @@ components:
           type: number
           description: Match confidence score (0.0 to 1.0).
         reasoning:
-          oneOf:
-            - type: string
-            - {}
+          type: string
+          nullable: true
           description: Why the two markets were matched.
       required:
         - marketA

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -203,6 +203,12 @@ export interface Trade {
 export interface UserTrade extends Trade {
     /** The order that produced this trade, if known. */
     orderId?: string;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    txHash?: string | null;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    chain?: string | null;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    blockNumber?: number | null;
 }
 
 
@@ -242,24 +248,46 @@ export interface Order {
     fee?: number;
     /** Fee rate in basis points applied to this order (e.g. 100 = 1%). */
     feeRateBps?: number;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    txHash?: string | null;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    chain?: string | null;
+    /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
+    blockNumber?: number | null;
 }
 
+/**
+ * A current position in a market.
+ *
+ * In hosted mode, `outcomeLabel`, `entryPrice`, `currentPrice` and
+ * `unrealizedPnL` may be null when the server cannot derive them
+ * (e.g. `with_mtm=false` or no fill history). Venue-direct callers
+ * continue to populate every field.
+ */
 export interface Position {
     /** The market this position is held in. */
     marketId: string;
     /** The outcome this position is held in. */
     outcomeId: string;
-    /** Human-readable label for the outcome held. */
-    outcomeLabel: string;
+    /** Human-readable label for the outcome held. Optional in hosted mode. */
+    outcomeLabel?: string | null;
     size: number;  // Positive for long, negative for short
-    /** Average entry price for the position (probability between 0.0 and 1.0). */
-    entryPrice: number;
-    /** Current mark price for the position (probability between 0.0 and 1.0). */
-    currentPrice: number;
-    /** Unrealized profit or loss at the current price (USD). */
-    unrealizedPnL: number;
+    /** Average entry price for the position (probability between 0.0 and 1.0). Optional in hosted mode when no fill history is available. */
+    entryPrice?: number | null;
+    /** Current mark price for the position (probability between 0.0 and 1.0). Optional in hosted mode when mark-to-market data is unavailable. */
+    currentPrice?: number | null;
+    /** Current market value of the position (size * currentPrice). Null when currentPrice is unavailable. */
+    currentValue?: number | null;
+    /** Unrealized profit or loss at the current price (USD). Optional in hosted mode when mark-to-market data is unavailable. */
+    unrealizedPnL?: number | null;
     /** Realized profit or loss booked so far (USD). */
     realizedPnL?: number;
+    /** Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues. */
+    txHash?: string | null;
+    /** Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues. */
+    chain?: string | null;
+    /** Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues. */
+    blockNumber?: number | null;
 }
 
 export interface Balance {
@@ -269,6 +297,8 @@ export interface Balance {
     /** Balance available to trade (excludes locked funds). */
     available: number;
     locked: number;  // In open orders
+    /** Hosted-mode: which venue this balance belongs to in a multi-venue response. Null when the balance is venue-agnostic. */
+    venue?: string | null;
 }
 
 export interface CreateOrderParams {
@@ -311,4 +341,9 @@ export interface BuiltOrder {
     };
     /** The raw, exchange-native payload. Always present. */
     raw: unknown;
+    /**
+     * Unix epoch (ms) when this built order expires server-side.
+     * Submitting after expiry returns BUILT_ORDER_EXPIRED.
+     */
+    expiry?: number | null;
 }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PMXT Hosted API",
     "description": "One API for every prediction market. Cross-venue search in under 10ms, a single unified schema, and the complete venue surface from reads to trades.",
-    "version": "2.49.0"
+    "version": "2.17.1"
   },
   "servers": [
     {
@@ -274,7 +274,28 @@
         "operationId": "fetchMarkets",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -491,23 +512,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_markets(\n    limit=10,\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    query=\"election\",\n    slug=\"BTC-USD\",\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    event_id=\"12345\",\n    page=1,\n    similarity_threshold=1,\n)"
           },
           {
             "lang": "python",
@@ -571,23 +577,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMarkets({\n  limit: 10,\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  query: \"election\",\n  slug: \"BTC-USD\",\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  eventId: \"12345\",\n  page: 1,\n  similarityThreshold: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -1055,7 +1046,28 @@
         "operationId": "fetchEvents",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -1288,23 +1300,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    series=\"value\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    series=\"value\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    series=\"value\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_events(\n    query=\"election\",\n    limit=10,\n    cursor=\"abc123\",\n    offset=0,\n    sort=\"volume\",\n    status=\"active\",\n    search_in=\"title\",\n    event_id=\"12345\",\n    slug=\"BTC-USD\",\n    series=\"value\",\n    filter=\"value\",\n    category=\"value\",\n    tags=[],\n)"
           },
           {
             "lang": "python",
@@ -1368,23 +1365,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  series: \"value\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  series: \"value\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  series: \"value\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchEvents({\n  query: \"election\",\n  limit: 10,\n  cursor: \"abc123\",\n  offset: 0,\n  sort: \"volume\",\n  status: \"active\",\n  searchIn: \"title\",\n  eventId: \"12345\",\n  slug: \"BTC-USD\",\n  series: \"value\",\n  filter: \"value\",\n  category: \"value\",\n  tags: [],\n});"
           },
           {
             "lang": "javascript",
@@ -1400,7 +1382,21 @@
         "operationId": "fetchSeries",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "opinion",
+                "polymarket_us",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "responses": {
@@ -1440,11 +1436,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Kalshi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
           },
@@ -1455,58 +1446,13 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Smarkets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_series()"
           },
           {
             "lang": "python",
@@ -1520,11 +1466,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Limitless({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
             "label": "Kalshi",
             "source": "import { Kalshi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Kalshi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
           },
@@ -1535,58 +1476,13 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchSeries();"
           },
           {
             "lang": "javascript",
@@ -2270,7 +2166,23 @@
         "operationId": "fetchOHLCV",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -2390,46 +2302,6 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
           },
           {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Smarkets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_ohlcv(\n    outcome_id=\"67890\",\n    resolution=\"1h\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
@@ -2468,46 +2340,6 @@
             "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOHLCV({\n  outcomeId: \"67890\",\n  resolution: \"1h\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
           }
         ]
       }
@@ -2518,7 +2350,27 @@
         "operationId": "fetchOrderBook",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us",
+                "suibets",
+                "router"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -2646,11 +2498,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
           },
@@ -2661,23 +2508,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_book(\n    outcome_id=\"67890\",\n    limit=10,\n    side=\"yes\",\n    outcome=\"value\",\n    since=1,\n    until=1,\n)"
           },
           {
             "lang": "python",
@@ -2726,11 +2558,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
           },
@@ -2741,23 +2568,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBook({\n  outcomeId: \"67890\",\n  limit: 10,\n  side: \"yes\",\n  outcome: \"value\",\n  since: 1,\n  until: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -2773,7 +2585,18 @@
         "operationId": "fetchOrderBooks",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -2842,11 +2665,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Kalshi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
           },
@@ -2856,74 +2674,9 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.KalshiDemo(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
           },
           {
-            "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Smarkets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order_books()"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Limitless({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
           },
           {
             "lang": "javascript",
@@ -2934,66 +2687,6 @@
             "lang": "javascript",
             "label": "KalshiDemo",
             "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new KalshiDemo({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrderBooks();"
           }
         ]
       }
@@ -3004,7 +2697,23 @@
         "operationId": "fetchTrades",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -3111,48 +2820,8 @@
           },
           {
             "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_trades(\n    outcome_id=\"67890\",\n    start=\"value\",\n    end=\"value\",\n    limit=10,\n)"
           },
           {
             "lang": "javascript",
@@ -3191,48 +2860,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchTrades({\n  outcomeId: \"67890\",\n  start: \"value\",\n  end: \"value\",\n  limit: 10,\n});"
           }
         ]
       }
@@ -3243,7 +2872,26 @@
         "operationId": "createOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3362,31 +3010,6 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
@@ -3440,31 +3063,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           }
         ]
       }
@@ -3475,7 +3073,21 @@
         "operationId": "buildOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3545,11 +3157,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
@@ -3560,28 +3167,8 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
             "lang": "python",
@@ -3594,39 +3181,9 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -3640,28 +3197,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           },
           {
             "lang": "javascript",
@@ -3672,31 +3209,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
           }
         ]
       }
@@ -3707,7 +3219,21 @@
         "operationId": "submitOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -3777,11 +3303,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
@@ -3792,28 +3313,8 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
           {
             "lang": "python",
@@ -3826,39 +3327,9 @@
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nbuilt = exchange.build_order(market_id=\"12345\", side=\"buy\", type=\"limit\", amount=10, price=0.55)\nresult = exchange.submit_order(built)"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           },
           {
             "lang": "javascript",
@@ -3872,28 +3343,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           },
           {
             "lang": "javascript",
@@ -3904,31 +3355,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst built = await exchange.buildOrder({ marketId: \"12345\", side: \"buy\", type: \"limit\", amount: 10, price: 0.55 });\nconst result = await exchange.submitOrder(built);"
           }
         ]
       }
@@ -3939,7 +3365,24 @@
         "operationId": "cancelOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "opinion",
+                "metaculus",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           }
         ],
         "requestBody": {
@@ -4029,16 +3472,6 @@
           },
           {
             "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
           },
@@ -4056,31 +3489,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.cancel_order(order_id=\"ord-001\")"
           },
           {
             "lang": "javascript",
@@ -4109,16 +3517,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
           },
@@ -4136,31 +3534,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.cancelOrder({ orderId: \"ord-001\" });"
           }
         ]
       }
@@ -4171,7 +3544,23 @@
         "operationId": "fetchOrder",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "probable",
+                "baozi",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4216,11 +3605,6 @@
           },
           {
             "lang": "python",
-            "label": "Limitless",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Kalshi",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Kalshi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
@@ -4241,18 +3625,8 @@
           },
           {
             "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
           {
             "lang": "python",
@@ -4265,39 +3639,9 @@
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
           },
           {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_order(order_id=\"ord-001\")"
-          },
-          {
             "lang": "javascript",
             "label": "Polymarket",
             "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Limitless({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           },
           {
             "lang": "javascript",
@@ -4321,18 +3665,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           },
           {
             "lang": "javascript",
@@ -4343,31 +3677,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOrder({ orderId: \"ord-001\" });"
           }
         ]
       }
@@ -4378,7 +3687,25 @@
         "operationId": "fetchOpenOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4461,11 +3788,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
           },
@@ -4473,31 +3795,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_open_orders(market_id=\"12345\")"
           },
           {
             "lang": "javascript",
@@ -4541,11 +3838,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
           },
@@ -4553,31 +3845,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchOpenOrders({ marketId: \"12345\" });"
           }
         ]
       }
@@ -4588,7 +3855,24 @@
         "operationId": "fetchMyTrades",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4703,11 +3987,6 @@
           },
           {
             "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Myriad",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4718,11 +3997,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4730,31 +4004,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_my_trades(\n    outcome_id=\"67890\",\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "javascript",
@@ -4783,11 +4032,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Myriad",
             "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
@@ -4798,11 +4042,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
@@ -4810,31 +4049,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchMyTrades({\n  outcomeId: \"67890\",\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -4845,7 +4059,20 @@
         "operationId": "fetchClosedOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "opinion",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -4926,11 +4153,6 @@
         "x-codeSamples": [
           {
             "lang": "python",
-            "label": "Polymarket",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Limitless",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -4946,68 +4168,13 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_closed_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "javascript",
-            "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
@@ -5026,63 +4193,13 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchClosedOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -5093,7 +4210,20 @@
         "operationId": "fetchAllOrders",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "opinion",
+                "smarkets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -5174,11 +4304,6 @@
         "x-codeSamples": [
           {
             "lang": "python",
-            "label": "Polymarket",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Limitless",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Limitless(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
@@ -5194,68 +4319,13 @@
           },
           {
             "lang": "python",
-            "label": "Probable",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Probable(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Baozi",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Baozi(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Myriad",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Myriad(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Opinion",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "PolymarketUs",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_all_orders(\n    market_id=\"12345\",\n    since=\"value\",\n    until=\"value\",\n    limit=10,\n    cursor=\"abc123\",\n)"
-          },
-          {
-            "lang": "javascript",
-            "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
@@ -5274,63 +4344,13 @@
           },
           {
             "lang": "javascript",
-            "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Probable({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Baozi({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Myriad({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Opinion",
             "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchAllOrders({\n  marketId: \"12345\",\n  since: \"value\",\n  until: \"value\",\n  limit: 10,\n  cursor: \"abc123\",\n});"
           }
         ]
       }
@@ -5341,7 +4361,26 @@
         "operationId": "fetchPositions",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "opinion",
+                "smarkets",
+                "polymarket_us",
+                "suibets"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -5424,11 +4463,6 @@
           },
           {
             "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
           },
@@ -5439,28 +4473,8 @@
           },
           {
             "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Suibets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_positions(address=\"0xabc...\")"
           },
           {
             "lang": "javascript",
@@ -5504,11 +4518,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
           },
@@ -5519,28 +4528,8 @@
           },
           {
             "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Suibets",
             "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchPositions({ address: \"0xabc...\" });"
           }
         ]
       }
@@ -5551,7 +4540,24 @@
         "operationId": "fetchBalance",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ExchangeParam"
+            "in": "path",
+            "name": "exchange",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "kalshi",
+                "kalshi-demo",
+                "limitless",
+                "probable",
+                "baozi",
+                "myriad",
+                "smarkets",
+                "polymarket_us"
+              ]
+            },
+            "required": true,
+            "description": "The prediction market exchange to target."
           },
           {
             "in": "query",
@@ -5629,16 +4635,6 @@
           },
           {
             "lang": "python",
-            "label": "Opinion",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Opinion(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Metaculus",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Metaculus(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
             "label": "Smarkets",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Smarkets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
           },
@@ -5646,31 +4642,6 @@
             "lang": "python",
             "label": "PolymarketUs",
             "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.PolymarketUs(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Hyperliquid",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Hyperliquid(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "GeminiTitan",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.GeminiTitan(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Suibets",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Suibets(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Mock",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Mock(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
-          },
-          {
-            "lang": "python",
-            "label": "Router",
-            "source": "import pmxt\n\n# API key optional — enables faster catalog-backed lookups\nexchange = pmxt.Router(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n)\nresult = exchange.fetch_balance(address=\"0xabc...\")"
           },
           {
             "lang": "javascript",
@@ -5709,16 +4680,6 @@
           },
           {
             "lang": "javascript",
-            "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Opinion({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Metaculus({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
             "label": "Smarkets",
             "source": "import { Smarkets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Smarkets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
           },
@@ -5726,31 +4687,6 @@
             "lang": "javascript",
             "label": "PolymarketUs",
             "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new PolymarketUs({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Hyperliquid({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new GeminiTitan({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Suibets({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Mock({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
-          },
-          {
-            "lang": "javascript",
-            "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// API key optional — enables faster catalog-backed lookups\nconst exchange = new Router({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n});\nconst result = await exchange.fetchBalance({ address: \"0xabc...\" });"
           }
         ]
       }
@@ -10429,9 +9365,96 @@
       },
       "ErrorDetail": {
         "type": "object",
+        "description": "Structured error envelope returned inside `BaseResponse.error` and `ErrorResponse.error`. Hosted-mode endpoints populate `code`, `retryable`, and optionally `exchange` / `detail`; legacy local-mode endpoints may still return only `message`.",
         "properties": {
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable error code. Hosted-mode errors use the `HostedTradingError` family (e.g. `INSUFFICIENT_ESCROW_BALANCE`, `BUILT_ORDER_EXPIRED`); pre-hosted local errors use the legacy family (e.g. `BAD_REQUEST`, `NOT_FOUND`).",
+            "enum": [
+              "HOSTED_TRADING_ERROR",
+              "INSUFFICIENT_ESCROW_BALANCE",
+              "ORDER_SIZE_TOO_SMALL",
+              "INVALID_API_KEY",
+              "OUTCOME_NOT_FOUND",
+              "CATALOG_UNAVAILABLE",
+              "BUILT_ORDER_EXPIRED",
+              "INVALID_SIGNATURE",
+              "NO_LIQUIDITY",
+              "MISSING_WALLET_ADDRESS",
+              "BAD_REQUEST",
+              "AUTHENTICATION_ERROR",
+              "PERMISSION_DENIED",
+              "NOT_FOUND",
+              "ORDER_NOT_FOUND",
+              "MARKET_NOT_FOUND",
+              "EVENT_NOT_FOUND",
+              "RATE_LIMIT_EXCEEDED",
+              "INVALID_ORDER",
+              "INSUFFICIENT_FUNDS",
+              "VALIDATION_ERROR",
+              "NETWORK_ERROR",
+              "EXCHANGE_NOT_AVAILABLE",
+              "NOT_SUPPORTED"
+            ]
+          },
+          "retryable": {
+            "type": "boolean",
+            "description": "Hint for clients: when `true`, the same request may succeed on retry (e.g. transient network or rate-limit conditions); when `false`, the caller should not retry without modifying the request."
+          },
+          "exchange": {
+            "type": "string",
+            "nullable": true,
+            "description": "Venue the error originated from, when known (e.g. 'polymarket', 'kalshi')."
+          },
+          "detail": {
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true,
+            "description": "Free-form hosted-mode detail blob. Shape depends on `code` — e.g. for `INSUFFICIENT_ESCROW_BALANCE` it may include `{ requested, available }`; for `ORDER_SIZE_TOO_SMALL` it may include `{ min }`; for `BUILT_ORDER_EXPIRED` it may include `{ expiry }`."
+          }
+        }
+      },
+      "ExchangeOptions": {
+        "type": "object",
+        "description": "Constructor-level options for venue clients (Polymarket, Kalshi, Opinion, etc.).\nHosted mode is the default when pmxtApiKey is set; otherwise the SDK runs against\na local sidecar with venue credentials.",
+        "properties": {
+          "pmxtApiKey": {
+            "type": "string",
+            "description": "PMXT customer API key. When set, the SDK routes to api.pmxt.dev (catalog) and trade.pmxt.dev (trading). Get one at pmxt.dev/dashboard."
+          },
+          "walletAddress": {
+            "type": "string",
+            "nullable": true,
+            "description": "EVM wallet address for hosted reads/writes. Required for endpoints that operate on a wallet (balances, positions, trades, open orders)."
+          },
+          "signer": {
+            "type": "object",
+            "nullable": true,
+            "description": "Optional pre-built signer for hosted writes. If absent and privateKey is set, the SDK auto-wraps privateKey into a signer."
+          },
+          "privateKey": {
+            "type": "string",
+            "nullable": true,
+            "description": "Private key. In hosted mode, used to derive an EIP-712 signer for writes (wraps into EthAccountSigner/EthersSigner). In self-hosted mode, used as the venue credential directly."
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Explicit base URL override. When unset, the SDK uses api.pmxt.dev when pmxtApiKey is set, or the local sidecar otherwise."
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true,
+            "description": "Venue-side API key (e.g. Polymarket CLOB key). Only relevant for self-hosted mode."
+          },
+          "autoStartServer": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Auto-start the local sidecar when running self-hosted. Defaults to true when no pmxtApiKey is set, false when hosted."
           }
         }
       },
@@ -10720,21 +9743,13 @@
             "description": "Human-readable series title (e.g. \"ATP Match Winner\", \"WTA\")."
           },
           "description": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "Long-form series description."
           },
           "recurrence": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "Recurrence cadence the venue reports ('daily', 'weekly', 'annual', ...)."
           },
           "events": {
@@ -10745,21 +9760,13 @@
             "description": "Child events. Populated when fetched by id; the list form usually omits this to keep payloads small."
           },
           "url": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "Canonical venue URL for the series."
           },
           "image": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "Venue-hosted image."
           },
           "sourceExchange": {
@@ -10940,6 +9947,21 @@
           "orderId": {
             "type": "string",
             "description": "The order that produced this trade, if known."
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
+          },
+          "chain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
+          },
+          "blockNumber": {
+            "type": "number",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
           }
         },
         "required": [
@@ -11023,6 +10045,21 @@
           "feeRateBps": {
             "type": "number",
             "description": "Fee rate in basis points applied to this order (e.g. 100 = 1%)."
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
+          },
+          "chain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
+          },
+          "blockNumber": {
+            "type": "number",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues."
           }
         },
         "required": [
@@ -11040,6 +10077,7 @@
       },
       "Position": {
         "type": "object",
+        "description": "A current position in a market. In hosted mode, `outcomeLabel`, `entryPrice`, `currentPrice` and `unrealizedPnL` may be null when the server cannot derive them (e.g. `with_mtm=false` or no fill history). Venue-direct callers continue to populate every field.",
         "properties": {
           "marketId": {
             "type": "string",
@@ -11051,7 +10089,8 @@
           },
           "outcomeLabel": {
             "type": "string",
-            "description": "Human-readable label for the outcome held."
+            "nullable": true,
+            "description": "Human-readable label for the outcome held. Optional in hosted mode."
           },
           "size": {
             "type": "number",
@@ -11059,29 +10098,48 @@
           },
           "entryPrice": {
             "type": "number",
-            "description": "Average entry price for the position (probability between 0.0 and 1.0)."
+            "nullable": true,
+            "description": "Average entry price for the position (probability between 0.0 and 1.0). Optional in hosted mode when no fill history is available."
           },
           "currentPrice": {
             "type": "number",
-            "description": "Current mark price for the position (probability between 0.0 and 1.0)."
+            "nullable": true,
+            "description": "Current mark price for the position (probability between 0.0 and 1.0). Optional in hosted mode when mark-to-market data is unavailable."
+          },
+          "currentValue": {
+            "type": "number",
+            "nullable": true,
+            "description": "Current market value of the position (size * currentPrice). Null when currentPrice is unavailable."
           },
           "unrealizedPnL": {
             "type": "number",
-            "description": "Unrealized profit or loss at the current price (USD)."
+            "nullable": true,
+            "description": "Unrealized profit or loss at the current price (USD). Optional in hosted mode when mark-to-market data is unavailable."
           },
           "realizedPnL": {
             "type": "number",
             "description": "Realized profit or loss booked so far (USD)."
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues."
+          },
+          "chain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues."
+          },
+          "blockNumber": {
+            "type": "number",
+            "nullable": true,
+            "description": "Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues."
           }
         },
         "required": [
           "marketId",
           "outcomeId",
-          "outcomeLabel",
-          "size",
-          "entryPrice",
-          "currentPrice",
-          "unrealizedPnL"
+          "size"
         ]
       },
       "Balance": {
@@ -11102,6 +10160,11 @@
           "locked": {
             "type": "number",
             "description": "In open orders"
+          },
+          "venue": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hosted-mode: which venue this balance belongs to in a multi-venue response. Null when the balance is venue-agnostic."
           }
         },
         "required": [
@@ -11529,6 +10592,11 @@
           },
           "raw": {
             "description": "The raw, exchange-native payload. Always present."
+          },
+          "expiry": {
+            "type": "number",
+            "nullable": true,
+            "description": "Unix epoch (ms) when this built order expires server-side. Submitting after expiry returns BUILT_ORDER_EXPIRED."
           }
         },
         "required": [
@@ -11959,28 +11027,16 @@
             "type": "number"
           },
           "reasoning": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ]
+            "type": "string",
+            "nullable": true
           },
           "bestBid": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {}
-            ]
+            "type": "number",
+            "nullable": true
           },
           "bestAsk": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {}
-            ]
+            "type": "number",
+            "nullable": true
           }
         },
         "required": [
@@ -12031,28 +11087,16 @@
             "type": "number"
           },
           "reasoning": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ]
+            "type": "string",
+            "nullable": true
           },
           "bestBid": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {}
-            ]
+            "type": "number",
+            "nullable": true
           },
           "bestAsk": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {}
-            ]
+            "type": "number",
+            "nullable": true
           },
           "venue": {
             "type": "string"
@@ -12189,12 +11233,8 @@
             "description": "Match confidence score (0.0 to 1.0)."
           },
           "reasoning": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {}
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "Why the two markets were matched."
           }
         },


### PR DESCRIPTION
Brings `core/src/server/openapi.yaml` and the auto-generated `docs/api-reference/openapi.json` in line with v2.49.0. SDK models (Python + TypeScript) were updated in 2.49.0; the schemas were stale and downstream codegen consumers missed the new hosted-mode fields.

## Schema changes

- **Order / UserTrade / Position**: + nullable `txHash`, `chain`, `blockNumber`
- **Position**: `required` trimmed from `[marketId, outcomeId, outcomeLabel, size, entryPrice, currentPrice, unrealizedPnL]` to `[marketId, outcomeId, size]` (the other four became optional in 2.49.0). + new `currentValue` field.
- **Balance**: + nullable `venue`
- **BuiltOrder**: + nullable `expiry`
- **ErrorDetail**: expanded from `{message}` to full envelope `{message, code (24-value enum), retryable, exchange?, detail?}`
- **ExchangeOptions**: new component schema (`pmxtApiKey`, `walletAddress`, `signer`, `privateKey`, `baseUrl`, `apiKey`, `autoStartServer`)

## How

Both `openapi.yaml` and `openapi.json` regenerated via `node core/scripts/generate-openapi.js`. Source edits in `core/src/types.ts` + the generator script itself (AST extractor now emits `nullable: true` for `T | null` unions; static schemas expanded).

## Tests
- `npx tsc --noEmit` clean
- `npm test` 9/9 pass on openapi/schema/types subset