### PR TITLE
feat(docs): per-method hosted/self-hosted toggle on Group A reference pages (v2.49.2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.49.2] - 2026-06-09
+
+Per-method docs follow-up to 2.49.1 — every Group A method (`createOrder`, `buildOrder`, `submitOrder`, `cancelOrder`, `fetchBalance`, `fetchPositions`, `fetchOpenOrders`, `fetchMyTrades`, `fetchOrder`, `fetchClosedOrders`, `fetchAllOrders`) now has a synchronized `Hosted (recommended)` / `Self-hosted` tab toggle on its reference page, so customers see the hosted endpoint and the v2.49 SDK constructor shape by default and can flip to the local-sidecar variant in place. Mintlify synchronizes tab selection across pages via shared label keys, so the choice persists as the user navigates the API Reference.
+
+### Added
+
+- **Docs (`docs/api-reference/`)**: 11 new shadow MDX files — one per Group A method — wrapping the existing OpenAPI auto-render in a `<Tabs>` toggle. `Hosted (recommended)` tab listed first on every page so it's the default; `Self-hosted` second. Tab labels are byte-identical across all 11 files for cross-page sync.
+- **Core (`openapi-hosted.json`)**: 9 new operations documenting the `trade.pmxt.dev/v0/*` trading surface — `buildOrderHosted` (POST `/v0/trade/build-order`), `submitOrderHosted` (POST `/v0/trade/submit-order`), `createOrderHosted` (SDK-convenience POST `/v0/trade/create-order` documentation entry), `cancelOrderHosted` (POST `/v0/orders/cancel/build`), `fetchBalanceHosted` (GET `/v0/user/{address}/balances`), `fetchPositionsHosted` (GET `/v0/user/{address}/positions`), `fetchOpenOrdersHosted` (GET `/v0/orders/open`), `fetchMyTradesHosted` (GET `/v0/user/{address}/trades`), `fetchOrderHosted` (GET `/v0/orders/{order_id}`). Each carries Python + TypeScript `x-codeSamples` using the v2.49 hosted constructor (`pmxtApiKey`, `walletAddress`, `privateKey`), error responses covering 401/403/404/410/422/503, and bearer auth via the existing `bearerAuth` security scheme. Plus 10 new component schemas for the v0 request/response shapes, all referencing existing components (`Order`, `Balance`, etc.) from 2.49.1.
+- **Docs (`docs.json`)**: Trading and "Orders & Positions" sidebar groups now reference the 11 shadow MDX slugs directly, so Mintlify renders the toggle pages instead of auto-generating from `openapi.json`.
+
+### Fixed
+
+- **Core (`createOrder` / `buildOrder` code samples)**: Pre-existing JSDoc rot — the auto-generated reference pages showed `type="market"` combined with `price=0.55`, an incoherent combination since price is only meaningful for limit orders. Replaced with coherent limit-order samples across all 16 venues (32 createOrder + 32 buildOrder samples, 64 line changes total). The fix lives in `core/scripts/generate-openapi.js`'s `PARAM_OVERRIDES` map so future regeneration emits the correct shape.
+
+### Not addressed (out of scope, flagged for follow-up)
+
+- **`fetchClosedOrdersHosted` / `fetchAllOrdersHosted`**: no underlying hosted endpoint exists — both methods raise `NotSupported` in hosted mode (closed orders are modeled as trades; use `fetchMyTrades` for historical fills). The shadow MDX files surface this via a `<Warning>` on the Hosted tab linking to `fetchMyTrades`.
+- **Escrow methods**: `client.escrow.{approve, deposit, withdraw, withdrawals}` aren't in Group A and so don't have toggle pages yet. They're hosted-only (no self-hosted variant exists), so a follow-up could add single-tab reference pages.
+- **Generator capability map gap**: `buildCapabilityMap()` in `core/scripts/generate-openapi.js` only instantiates 13 of the 16 exported exchange classes, omitting `Hyperliquid`, `GeminiTitan`, and `Mock`. Re-running the generator drops their `x-codeSamples`. The merged main spec retains the missing samples from a prior generator run; the surgical fix here didn't disturb them. Worth a real fix in a follow-up.
+
 ## [2.49.1] - 2026-06-08
 
 Positioning-shift patch on top of 2.49.0 — the hosted trading mode shipped in 2.49.0 but the docs, READMEs, and OpenAPI schemas still defaulted to the self-hosted sidecar path. This release flips the default everywhere the SDK + docs surface a customer hits: hosted PMXT is the primary experience; self-hosting becomes the advanced escape hatch. No SDK runtime behavior changes — pure documentation, schema, and copy work. Marketing-site changes ship separately in a sibling pmxt-website PR.

--- a/core/scripts/generate-openapi.js
+++ b/core/scripts/generate-openapi.js
@@ -461,6 +461,28 @@ const PARAM_OVERRIDES = {
     fetchRelatedMarkets: [{ name: 'marketId', value: '12345' }],
     fetchMatchedMarkets: [{ name: 'minDifference', value: 0.05 }],
     fetchMatchedPrices: [{ name: 'minDifference', value: 0.05 }],
+    // Self-hosted createOrder / buildOrder samples: limit order shape only.
+    // The auto-extracted shape mixed `type: "market"` with `price: 0.55`,
+    // which is incoherent (price is only meaningful for limit orders) and
+    // tacked on internal-only fields (fee, tickSize, negRisk, onBehalfOf)
+    // that the average reader shouldn't see. A clean limit-order example
+    // is the simplest correct shape.
+    createOrder: [
+        { name: 'marketId', value: '12345' },
+        { name: 'outcomeId', value: '67890' },
+        { name: 'side', value: 'buy' },
+        { name: 'type', value: 'limit' },
+        { name: 'amount', value: 10 },
+        { name: 'price', value: 0.55 },
+    ],
+    buildOrder: [
+        { name: 'marketId', value: '12345' },
+        { name: 'outcomeId', value: '67890' },
+        { name: 'side', value: 'buy' },
+        { name: 'type', value: 'limit' },
+        { name: 'amount', value: 10 },
+        { name: 'price', value: 0.55 },
+    ],
 };
 
 const FULL_OVERRIDES = {

--- a/docs/api-reference/buildOrder.mdx
+++ b/docs/api-reference/buildOrder.mdx
@@ -1,0 +1,138 @@
+---
+title: buildOrder
+description: Build an order payload without submitting it. Hosted returns EIP-712 typed data to sign locally.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `POST trade.pmxt.dev/v0/trade/build-order` and is
+      the default when `pmxt_api_key` is set. Returns a `built_order_id` plus EIP-712
+      typed data the wallet must sign before calling
+      [`submitOrder`](/api-reference/submitOrder). Pass catalog UUIDs
+      (`market_id`, `outcome_id`), not venue-native ids. See
+      [hosted trading](/concepts/hosted-trading) for the end-to-end flow.
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+        private_key="0x...",
+    )
+    built = client.build_order(
+        market_id="12345678-1234-1234-1234-123456789abc",
+        outcome_id="abcdef01-2345-6789-abcd-ef0123456789",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    print(built.expiry, built.raw)
+    # Sign + submit later with client.submit_order(built).
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+      privateKey: "0x...",
+    });
+
+    const built = await client.buildOrder({
+      marketId: "12345678-1234-1234-1234-123456789abc",
+      outcomeId: "abcdef01-2345-6789-abcd-ef0123456789",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    console.log(built.expiry, built.raw);
+    // Sign + submit later with client.submitOrder(built).
+    ```
+
+    ```bash curl
+    curl -X POST "https://trade.pmxt.dev/v0/trade/build-order" \
+      -H "Authorization: Bearer $PMXT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "market_id": "12345678-1234-1234-1234-123456789abc",
+        "outcome_id": "abcdef01-2345-6789-abcd-ef0123456789",
+        "side": "buy",
+        "order_type": "limit",
+        "amount": 10,
+        "denom": "shares",
+        "price": 0.55,
+        "user_address": "0xYourWallet"
+      }'
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `POST localhost:3847/api/{exchange}/buildOrder`. Returns the venue-native
+      signed order or request body for inspection or deferred submission via
+      [`submitOrder`](/api-reference/submitOrder). See
+      [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        api_secret="YOUR_VENUE_API_SECRET",
+        passphrase="YOUR_PASSPHRASE",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    built = client.build_order(
+        market_id="12345",
+        outcome_id="67890",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    print(built.exchange, built.raw)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      apiSecret: "YOUR_VENUE_API_SECRET",
+      passphrase: "YOUR_PASSPHRASE",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const built = await client.buildOrder({
+      marketId: "12345",
+      outcomeId: "67890",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    console.log(built.exchange, built.raw);
+    ```
+
+    ```bash curl
+    curl -X POST "http://localhost:3847/api/polymarket/buildOrder" \
+      -H "Content-Type: application/json" \
+      -d '{"args":[{"marketId":"12345","outcomeId":"67890","side":"buy","type":"limit","amount":10,"price":0.55}]}'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/cancelOrder.mdx
+++ b/docs/api-reference/cancelOrder.mdx
@@ -1,0 +1,99 @@
+---
+title: cancelOrder
+description: Cancel an open order. Hosted uses a two-call build -> sign -> cancel chain.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path is a two-call chain: `POST trade.pmxt.dev/v0/orders/cancel/build`
+      returns EIP-712 typed data for the wallet to sign, then
+      `POST trade.pmxt.dev/v0/orders/cancel` submits the signature. The SDK's
+      `cancel_order()` chains both calls. Get a key at
+      [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+        private_key="0x...",
+    )
+    cancelled = client.cancel_order("order_abc123")
+    print(cancelled.id, cancelled.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+      privateKey: "0x...",
+    });
+
+    const cancelled = await client.cancelOrder("order_abc123");
+    console.log(cancelled.id, cancelled.status);
+    ```
+
+    ```bash curl
+    # Step 1: build
+    curl -X POST "https://trade.pmxt.dev/v0/orders/cancel/build" \
+      -H "Authorization: Bearer $PMXT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"order_id":"order_abc123","user_address":"0xYourWallet"}'
+
+    # Step 2: sign the typed_data locally, then submit
+    curl -X POST "https://trade.pmxt.dev/v0/orders/cancel" \
+      -H "Authorization: Bearer $PMXT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"cancel_id":"cnl_abc...","signature":"0x..."}'
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `POST localhost:3847/api/{exchange}/cancelOrder` with the venue-native order id.
+      The sidecar signs and submits the cancel directly to the venue. See
+      [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    cancelled = client.cancel_order("0xVenueOrderId")
+    print(cancelled.id, cancelled.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const cancelled = await client.cancelOrder("0xVenueOrderId");
+    console.log(cancelled.id, cancelled.status);
+    ```
+
+    ```bash curl
+    curl -X POST "http://localhost:3847/api/polymarket/cancelOrder" \
+      -H "Content-Type: application/json" \
+      -d '{"args":["0xVenueOrderId"]}'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/createOrder.mdx
+++ b/docs/api-reference/createOrder.mdx
@@ -1,0 +1,123 @@
+---
+title: createOrder
+description: Place an order. Hosted chains build -> sign -> submit; self-hosted hits the venue directly.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path chains [`buildOrderHosted`](/api-reference/buildOrder) ->
+      local EIP-712 signing -> [`submitOrderHosted`](/api-reference/submitOrder)
+      inside the SDK. Pass catalog UUIDs (`market_id`, `outcome_id`), not venue-native
+      ids. Available on Polymarket and Opinion in hosted mode; other venues stay
+      self-hosted. See [hosted trading](/concepts/hosted-trading) for the end-to-end
+      flow. Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+        private_key="0x...",
+    )
+    order = client.create_order(
+        market_id="12345678-1234-1234-1234-123456789abc",
+        outcome_id="abcdef01-2345-6789-abcd-ef0123456789",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    print(order.id, order.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+      privateKey: "0x...",
+    });
+
+    const order = await client.createOrder({
+      marketId: "12345678-1234-1234-1234-123456789abc",
+      outcomeId: "abcdef01-2345-6789-abcd-ef0123456789",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    console.log(order.id, order.status);
+    ```
+
+    ```bash curl
+    # Raw HTTP requires manual build -> sign -> submit. See buildOrderHosted /
+    # submitOrderHosted in the openapi-hosted spec for the two-call shape.
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `POST localhost:3847/api/{exchange}/createOrder`. Pass venue-native
+      `marketId` / `outcomeId`. The sidecar holds venue credentials and signs locally
+      against the venue's CLOB. See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        api_secret="YOUR_VENUE_API_SECRET",
+        passphrase="YOUR_PASSPHRASE",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    order = client.create_order(
+        market_id="12345",
+        outcome_id="67890",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    print(order.id, order.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      apiSecret: "YOUR_VENUE_API_SECRET",
+      passphrase: "YOUR_PASSPHRASE",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const order = await client.createOrder({
+      marketId: "12345",
+      outcomeId: "67890",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    console.log(order.id, order.status);
+    ```
+
+    ```bash curl
+    curl -X POST "http://localhost:3847/api/polymarket/createOrder" \
+      -H "Content-Type: application/json" \
+      -d '{"args":[{"marketId":"12345","outcomeId":"67890","side":"buy","type":"limit","amount":10,"price":0.55}]}'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchAllOrders.mdx
+++ b/docs/api-reference/fetchAllOrders.mdx
@@ -1,0 +1,85 @@
+---
+title: fetchAllOrders
+description: All historical orders. Hosted mode models these as trades; use fetchMyTrades.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Warning>
+      **Not available in hosted mode.** All historical orders are modelled as
+      trades -- use [`fetchMyTrades`](/api-reference/fetchMyTrades) for fills and
+      [`fetchOpenOrders`](/api-reference/fetchOpenOrders) for resting orders.
+      Calling `fetch_all_orders()` in hosted mode raises `NotSupported`.
+    </Warning>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    # Use fetch_my_trades() + fetch_open_orders() instead.
+    fills = client.fetch_my_trades()
+    open_orders = client.fetch_open_orders()
+    print(f"{len(fills)} fills, {len(open_orders)} open")
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    // Use fetchMyTrades() + fetchOpenOrders() instead.
+    const fills = await client.fetchMyTrades();
+    const openOrders = await client.fetchOpenOrders();
+    console.log(`${fills.length} fills, ${openOrders.length} open`);
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchAllOrders` and returns every order
+      (open, filled, cancelled) the venue reports. See
+      [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    for order in client.fetch_all_orders():
+        print(order.id, order.status, order.filled)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    for (const order of await client.fetchAllOrders()) {
+      console.log(order.id, order.status, order.filled);
+    }
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchAllOrders"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchBalance.mdx
+++ b/docs/api-reference/fetchBalance.mdx
@@ -1,0 +1,93 @@
+---
+title: fetchBalance
+description: Read the wallet's escrow USDC balance (hosted) or venue-native balance (self-hosted).
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `GET trade.pmxt.dev/v0/user/{address}/balances` and is
+      the default for callers with a `pmxt_api_key`. The balance returned is USDC held
+      inside the PMXT `PreFundedEscrow` contract on behalf of the wallet.
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    balance = client.fetch_balance()
+    print(balance.amount, balance.currency)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    const balance = await client.fetchBalance();
+    console.log(balance.amount, balance.currency);
+    ```
+
+    ```bash curl
+    curl -G "https://trade.pmxt.dev/v0/user/0xYourWallet/balances" \
+      -H "Authorization: Bearer $PMXT_API_KEY"
+    ```
+    </CodeGroup>
+
+    See the [hosted `fetchBalanceHosted` operation](#) for the full request and response
+    schema, or [Hosted vs Self-hosted](/concepts/hosted-vs-self-hosted) for how this
+    differs from the venue-native balance.
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchBalance`. The balance returned is the
+      venue-native CLOB-proxy balance, not escrow USDC.
+      See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        api_secret="YOUR_VENUE_API_SECRET",
+        passphrase="YOUR_PASSPHRASE",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    balance = client.fetch_balance()
+    print(balance.amount, balance.currency)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      apiSecret: "YOUR_VENUE_API_SECRET",
+      passphrase: "YOUR_PASSPHRASE",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const balance = await client.fetchBalance();
+    console.log(balance.amount, balance.currency);
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchBalance"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchClosedOrders.mdx
+++ b/docs/api-reference/fetchClosedOrders.mdx
@@ -1,0 +1,82 @@
+---
+title: fetchClosedOrders
+description: Settled / cancelled orders. Hosted mode models these as trades; use fetchMyTrades.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Warning>
+      **Not available in hosted mode.** Settled and cancelled orders are modelled as
+      trades -- use [`fetchMyTrades`](/api-reference/fetchMyTrades) for historical fills.
+      Calling `fetch_closed_orders()` in hosted mode raises `NotSupported`.
+    </Warning>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    # Use fetch_my_trades() instead.
+    for trade in client.fetch_my_trades():
+        print(trade.id, trade.side, trade.amount, trade.price)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    // Use fetchMyTrades() instead.
+    for (const trade of await client.fetchMyTrades()) {
+      console.log(trade.id, trade.side, trade.amount, trade.price);
+    }
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchClosedOrders` and returns the venue's
+      historical orders directly. See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    for order in client.fetch_closed_orders():
+        print(order.id, order.status, order.filled)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    for (const order of await client.fetchClosedOrders()) {
+      console.log(order.id, order.status, order.filled);
+    }
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchClosedOrders"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchMyTrades.mdx
+++ b/docs/api-reference/fetchMyTrades.mdx
@@ -1,0 +1,87 @@
+---
+title: fetchMyTrades
+description: List historical fills for the wallet (hosted) or via the local sidecar.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `GET trade.pmxt.dev/v0/user/{address}/trades` and is
+      the default when `pmxt_api_key` is set. In hosted mode, **closed orders are
+      modelled as trades** -- use this endpoint instead of `fetchClosedOrders` /
+      `fetchAllOrders` (which raise `NotSupported`).
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    for trade in client.fetch_my_trades():
+        print(trade.id, trade.side, trade.amount, trade.price, trade.tx_hash)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    for (const trade of await client.fetchMyTrades()) {
+      console.log(trade.id, trade.side, trade.amount, trade.price, trade.txHash);
+    }
+    ```
+
+    ```bash curl
+    curl -G "https://trade.pmxt.dev/v0/user/0xYourWallet/trades" \
+      -H "Authorization: Bearer $PMXT_API_KEY"
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchMyTrades`. Trades are read directly from
+      the venue. See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    for trade in client.fetch_my_trades():
+        print(trade.id, trade.side, trade.amount, trade.price)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    for (const trade of await client.fetchMyTrades()) {
+      console.log(trade.id, trade.side, trade.amount, trade.price);
+    }
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchMyTrades"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchOpenOrders.mdx
+++ b/docs/api-reference/fetchOpenOrders.mdx
@@ -1,0 +1,87 @@
+---
+title: fetchOpenOrders
+description: List resting limit orders for the wallet (hosted) or via the local sidecar.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `GET trade.pmxt.dev/v0/orders/open?address={address}`
+      and is the default when `pmxt_api_key` is set. Optionally filter by `venue`
+      (`polymarket` or `opinion`). Get a key at
+      [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    for order in client.fetch_open_orders():
+        print(order.id, order.side, order.price, order.remaining)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    for (const order of await client.fetchOpenOrders()) {
+      console.log(order.id, order.side, order.price, order.remaining);
+    }
+    ```
+
+    ```bash curl
+    curl -G "https://trade.pmxt.dev/v0/orders/open" \
+      -H "Authorization: Bearer $PMXT_API_KEY" \
+      --data-urlencode "address=0xYourWallet"
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchOpenOrders`. Optional `marketId` query
+      param filters by market. See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    for order in client.fetch_open_orders():
+        print(order.id, order.side, order.price, order.remaining)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    for (const order of await client.fetchOpenOrders()) {
+      console.log(order.id, order.side, order.price, order.remaining);
+    }
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchOpenOrders"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchOrder.mdx
+++ b/docs/api-reference/fetchOrder.mdx
@@ -1,0 +1,84 @@
+---
+title: fetchOrder
+description: Look up a single order by ID (hosted) or via the local sidecar.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `GET trade.pmxt.dev/v0/orders/{order_id}` and is the
+      default when `pmxt_api_key` is set. The `order_id` is the same unified id
+      returned by `fetchOpenOrdersHosted` / the submit response.
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    order = client.fetch_order("order_abc123")
+    print(order.id, order.status, order.filled, order.remaining)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    const order = await client.fetchOrder("order_abc123");
+    console.log(order.id, order.status, order.filled, order.remaining);
+    ```
+
+    ```bash curl
+    curl "https://trade.pmxt.dev/v0/orders/order_abc123" \
+      -H "Authorization: Bearer $PMXT_API_KEY"
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchOrder?orderId={id}`. The id is the
+      venue-native order id. See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    order = client.fetch_order("0xVenueOrderId")
+    print(order.id, order.status, order.filled, order.remaining)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const order = await client.fetchOrder("0xVenueOrderId");
+    console.log(order.id, order.status, order.filled, order.remaining);
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchOrder?orderId=0xVenueOrderId"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/fetchPositions.mdx
+++ b/docs/api-reference/fetchPositions.mdx
@@ -1,0 +1,88 @@
+---
+title: fetchPositions
+description: List open positions held by the wallet across hosted venues, or via the local sidecar.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `GET trade.pmxt.dev/v0/user/{address}/positions`
+      and is the default when `pmxt_api_key` is set. `current_price`, `current_value`,
+      `entry_price`, `realized_pnl`, and `outcome_label` may be `null` when the server
+      doesn't yet have the data.
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+    )
+    for position in client.fetch_positions():
+        print(position.market_id, position.shares, position.current_value)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+    });
+
+    for (const position of await client.fetchPositions()) {
+      console.log(position.marketId, position.shares, position.currentValue);
+    }
+    ```
+
+    ```bash curl
+    curl -G "https://trade.pmxt.dev/v0/user/0xYourWallet/positions" \
+      -H "Authorization: Bearer $PMXT_API_KEY"
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `GET localhost:3847/api/{exchange}/fetchPositions`. Positions are read directly
+      from the venue and always have populated `current_price` / `entry_price`.
+      See [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    for position in client.fetch_positions():
+        print(position.market_id, position.shares, position.current_value)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    for (const position of await client.fetchPositions()) {
+      console.log(position.marketId, position.shares, position.currentValue);
+    }
+    ```
+
+    ```bash curl
+    curl "http://localhost:3847/api/polymarket/fetchPositions"
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/api-reference/openapi-hosted.json
+++ b/docs/api-reference/openapi-hosted.json
@@ -9,6 +9,10 @@
     {
       "url": "https://api.pmxt.dev",
       "description": "Production"
+    },
+    {
+      "url": "https://trade.pmxt.dev",
+      "description": "Hosted trading (v0)"
     }
   ],
   "security": [
@@ -16,7 +20,687 @@
       "bearerAuth": []
     }
   ],
+  "tags": [
+    {
+      "name": "Trading (Hosted)",
+      "description": "Hosted trading endpoints. Build / submit / cancel orders via `trade.pmxt.dev/v0/*`. Hosted-mode is the default when `pmxt_api_key` is set."
+    },
+    {
+      "name": "Orders & Positions (Hosted)",
+      "description": "Hosted account reads. Open orders, fills, balances, and positions via `trade.pmxt.dev/v0/*`. Requires `pmxt_api_key` + `wallet_address`."
+    },
+    {
+      "name": "MatchedMarkets",
+      "description": "Cross-venue matched market and event clusters."
+    },
+    {
+      "name": "SQL",
+      "description": "Direct read-only SQL access to the catalog (Enterprise)."
+    }
+  ],
   "paths": {
+    "/v0/trade/build-order": {
+      "post": {
+        "summary": "Build Order (Hosted)",
+        "description": "Build a hosted-mode order from catalog `market_id` + `outcome_id`. Returns EIP-712 typed data for the caller to sign locally and then submit via `submitOrderHosted`. The wallet always controls the signature; the hosted server only holds USDC in escrow on behalf of the caller.\n\nSee [hosted trading](/concepts/hosted-trading) and the [signing guide](/guides/signing) for end-to-end flow.\n",
+        "tags": [
+          "Trading (Hosted)"
+        ],
+        "operationId": "buildOrderHosted",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildOrderHostedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Built order with typed data to sign.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildOrderHostedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient escrow balance to back the requested order size.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Outcome not found in the catalog.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid order parameters (e.g. price out of range, denom mismatch).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Catalog unavailable -- temporary upstream failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n    private_key=\"0x...\",\n)\nbuilt = client.build_order(\n    market_id=\"12345678-1234-1234-1234-123456789abc\",\n    outcome_id=\"abcdef01-2345-6789-abcd-ef0123456789\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)\nprint(built.expiry, built.raw)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n  privateKey: \"0x...\",\n});\n\nconst built = await client.buildOrder({\n  marketId: \"12345678-1234-1234-1234-123456789abc\",\n  outcomeId: \"abcdef01-2345-6789-abcd-ef0123456789\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});\nconsole.log(built.expiry, built.raw);\n"
+          }
+        ]
+      }
+    },
+    "/v0/trade/submit-order": {
+      "post": {
+        "summary": "Submit Order (Hosted)",
+        "description": "Submit a signed, previously-built order via `built_order_id`. The order must have been returned from `buildOrderHosted` within the expiry window. Returns the resulting `Order` once execution settles or queues.\n\nFor most callers, prefer `createOrderHosted`, which chains build -> sign -> submit in a single call.\n",
+        "tags": [
+          "Trading (Hosted)"
+        ],
+        "operationId": "submitOrderHosted",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitOrderHostedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order accepted by the hosted backend.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderV0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "`built_order_id` expired before submission. Re-run `buildOrderHosted` and submit again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid signature or malformed payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n    private_key=\"0x...\",\n)\nbuilt = client.build_order(\n    market_id=\"12345678-1234-1234-1234-123456789abc\",\n    outcome_id=\"abcdef01-2345-6789-abcd-ef0123456789\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)\norder = client.submit_order(built)\nprint(order.id, order.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n  privateKey: \"0x...\",\n});\n\nconst built = await client.buildOrder({\n  marketId: \"12345678-1234-1234-1234-123456789abc\",\n  outcomeId: \"abcdef01-2345-6789-abcd-ef0123456789\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});\nconst order = await client.submitOrder(built);\nconsole.log(order.id, order.status);\n"
+          }
+        ]
+      }
+    },
+    "/v0/trade/create-order": {
+      "post": {
+        "summary": "Create Order (Hosted)",
+        "description": "Hosted-mode `createOrder` chains `buildOrderHosted` -> local signing -> `submitOrderHosted` inside the SDK. There is no single HTTP endpoint -- this entry documents the convenience call pattern for SDK users.\n\nIf you need to inspect the typed data before signing (e.g. to display order details to an end user before they approve), call `buildOrderHosted` and `submitOrderHosted` directly.\n",
+        "tags": [
+          "Trading (Hosted)"
+        ],
+        "operationId": "createOrderHosted",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildOrderHostedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order accepted by the hosted backend.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderV0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient escrow balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Outcome not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid order parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Catalog unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n    private_key=\"0x...\",\n)\norder = client.create_order(\n    market_id=\"12345678-1234-1234-1234-123456789abc\",\n    outcome_id=\"abcdef01-2345-6789-abcd-ef0123456789\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)\nprint(order.id, order.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n  privateKey: \"0x...\",\n});\n\nconst order = await client.createOrder({\n  marketId: \"12345678-1234-1234-1234-123456789abc\",\n  outcomeId: \"abcdef01-2345-6789-abcd-ef0123456789\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});\nconsole.log(order.id, order.status);\n"
+          }
+        ]
+      }
+    },
+    "/v0/orders/cancel/build": {
+      "post": {
+        "summary": "Cancel Order -- Build (Hosted)",
+        "description": "Step 1 of the hosted cancel flow. Returns EIP-712 typed data for the caller to sign locally. Step 2 is `POST /v0/orders/cancel` with the resulting signature. The SDK's `cancelOrder()` chains both calls.\n",
+        "tags": [
+          "Trading (Hosted)"
+        ],
+        "operationId": "cancelOrderHosted",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelBuildHostedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cancel build response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelBuildHostedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid order ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n    private_key=\"0x...\",\n)\ncancelled = client.cancel_order(\"order_abc123\")\nprint(cancelled.id, cancelled.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n  privateKey: \"0x...\",\n});\n\nconst cancelled = await client.cancelOrder(\"order_abc123\");\nconsole.log(cancelled.id, cancelled.status);\n"
+          }
+        ]
+      }
+    },
+    "/v0/user/{address}/balances": {
+      "get": {
+        "summary": "Fetch Balance (Hosted)",
+        "description": "Returns the wallet's escrow USDC balance. Hosted `fetch_balance` returns USDC held inside the PMXT `PreFundedEscrow` contract on behalf of `address`, *not* the venue-native CLOB-proxy balance. See [hosted vs self-hosted](/concepts/hosted-vs-self-hosted) for the distinction.\n",
+        "tags": [
+          "Orders & Positions (Hosted)"
+        ],
+        "operationId": "fetchBalanceHosted",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "EVM wallet address (lowercase or checksum)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance for the wallet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalanceV0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Catalog or escrow indexer temporarily unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n)\nbalance = client.fetch_balance()\nprint(balance.amount, balance.currency)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n});\n\nconst balance = await client.fetchBalance();\nconsole.log(balance.amount, balance.currency);\n"
+          }
+        ]
+      }
+    },
+    "/v0/user/{address}/positions": {
+      "get": {
+        "summary": "Fetch Positions (Hosted)",
+        "description": "Returns open positions held by `address` across hosted venues.\n",
+        "tags": [
+          "Orders & Positions (Hosted)"
+        ],
+        "operationId": "fetchPositionsHosted",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "EVM wallet address."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Positions list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PositionV0"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Catalog or indexer temporarily unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n)\nfor position in client.fetch_positions():\n    print(position.market_id, position.shares, position.current_value)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n});\n\nfor (const position of await client.fetchPositions()) {\n  console.log(position.marketId, position.shares, position.currentValue);\n}\n"
+          }
+        ]
+      }
+    },
+    "/v0/orders/open": {
+      "get": {
+        "summary": "Fetch Open Orders (Hosted)",
+        "description": "Returns resting limit orders owned by `address`. Optionally filter by `venue`.\n",
+        "tags": [
+          "Orders & Positions (Hosted)"
+        ],
+        "operationId": "fetchOpenOrdersHosted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "EVM wallet address."
+          },
+          {
+            "in": "query",
+            "name": "venue",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "polymarket",
+                "opinion"
+              ]
+            },
+            "description": "Restrict to a single hosted venue."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Open orders list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderV0"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n)\nfor order in client.fetch_open_orders():\n    print(order.id, order.side, order.price, order.remaining)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n});\n\nfor (const order of await client.fetchOpenOrders()) {\n  console.log(order.id, order.side, order.price, order.remaining);\n}\n"
+          }
+        ]
+      }
+    },
+    "/v0/user/{address}/trades": {
+      "get": {
+        "summary": "Fetch My Trades (Hosted)",
+        "description": "Returns historical fills for `address`. In hosted mode, closed orders are modelled as trades -- use this endpoint instead of `fetchClosedOrders` / `fetchAllOrders` (which raise `NotSupported`).\n",
+        "tags": [
+          "Orders & Positions (Hosted)"
+        ],
+        "operationId": "fetchMyTradesHosted",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "EVM wallet address."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trade history.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserTradeV0"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n)\nfor trade in client.fetch_my_trades():\n    print(trade.id, trade.side, trade.amount, trade.price, trade.tx_hash)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n});\n\nfor (const trade of await client.fetchMyTrades()) {\n  console.log(trade.id, trade.side, trade.amount, trade.price, trade.txHash);\n}\n"
+          }
+        ]
+      }
+    },
+    "/v0/orders/{order_id}": {
+      "get": {
+        "summary": "Fetch Order (Hosted)",
+        "description": "Look up a single hosted order by its unified `order_id` (the same string returned by `fetchOpenOrdersHosted`).\n",
+        "tags": [
+          "Orders & Positions (Hosted)"
+        ],
+        "operationId": "fetchOrderHosted",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "order_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unified order id."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderV0"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing PMXT API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostedErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import pmxt\n\nclient = pmxt.Polymarket(\n    pmxt_api_key=\"YOUR_PMXT_API_KEY\",\n    wallet_address=\"0xYourWallet\",\n)\norder = client.fetch_order(\"order_abc123\")\nprint(order.id, order.status, order.filled, order.remaining)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "TypeScript",
+            "source": "import { Polymarket } from \"pmxtjs\";\n\nconst client = new Polymarket({\n  pmxtApiKey: \"YOUR_PMXT_API_KEY\",\n  walletAddress: \"0xYourWallet\",\n});\n\nconst order = await client.fetchOrder(\"order_abc123\");\nconsole.log(order.id, order.status, order.filled, order.remaining);\n"
+          }
+        ]
+      }
+    },
     "/v0/matched-event-clusters": {
       "get": {
         "summary": "Fetch matched event clusters",
@@ -850,6 +1534,490 @@
           },
           "window": {
             "type": "string"
+          }
+        }
+      },
+      "HostedErrorResponse": {
+        "type": "object",
+        "description": "Error envelope returned by `trade.pmxt.dev/v0/*` endpoints. Mirrors the `ErrorDetail` shape used inside `BaseResponse.error` from the sidecar spec.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string",
+                "description": "Stable hosted-mode error code.",
+                "enum": [
+                  "HOSTED_TRADING_ERROR",
+                  "INSUFFICIENT_ESCROW_BALANCE",
+                  "ORDER_SIZE_TOO_SMALL",
+                  "INVALID_API_KEY",
+                  "OUTCOME_NOT_FOUND",
+                  "CATALOG_UNAVAILABLE",
+                  "BUILT_ORDER_EXPIRED",
+                  "INVALID_SIGNATURE",
+                  "NO_LIQUIDITY",
+                  "MISSING_WALLET_ADDRESS",
+                  "ORDER_NOT_FOUND",
+                  "INVALID_ORDER"
+                ]
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "exchange": {
+                "type": "string",
+                "nullable": true
+              },
+              "detail": {
+                "type": "object",
+                "additionalProperties": {},
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "BuildOrderHostedRequest": {
+        "type": "object",
+        "description": "Hosted build-order request. Keys mirror the SDK constructor of an `Order`: pass catalog UUIDs (`market_id`, `outcome_id`), not venue-native ids.",
+        "required": [
+          "market_id",
+          "outcome_id",
+          "side",
+          "amount",
+          "user_address"
+        ],
+        "properties": {
+          "market_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Catalog market UUID."
+          },
+          "outcome_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Catalog outcome UUID."
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "order_type": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit"
+            ],
+            "default": "market"
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Order size. For `market` buys, in USDC; for `market` sells / `limit`, in shares."
+          },
+          "denom": {
+            "type": "string",
+            "enum": [
+              "shares",
+              "usdc"
+            ],
+            "default": "shares"
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "nullable": true,
+            "description": "Required for `limit` orders. Probability in [0, 1]."
+          },
+          "slippage_pct": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "nullable": true
+          },
+          "user_address": {
+            "type": "string",
+            "description": "EVM wallet address that will sign the resulting typed data."
+          }
+        }
+      },
+      "BuildOrderHostedResponse": {
+        "type": "object",
+        "description": "Hosted build-order response. The caller must sign `typed_data` locally (and `pull_typed_data` if present) and POST the signatures back via `submitOrderHosted` before the order expires.",
+        "required": [
+          "built_order_id",
+          "side",
+          "typed_data",
+          "quote"
+        ],
+        "properties": {
+          "built_order_id": {
+            "type": "string",
+            "description": "Opaque server-side key used by `submitOrderHosted` to look up the build context."
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "typed_data": {
+            "type": "object",
+            "description": "EIP-712 typed data for the order. Sign locally with the wallet that matches `user_address`."
+          },
+          "pull_typed_data": {
+            "type": "object",
+            "nullable": true,
+            "description": "Optional secondary EIP-712 payload for venues that require a pull-authorization (e.g. Polymarket neg-risk markets)."
+          },
+          "quote": {
+            "type": "object",
+            "description": "Pre-trade quote: expected average fill price, slippage, and fees.",
+            "properties": {
+              "best_price": {
+                "type": "number"
+              },
+              "expected_avg_price": {
+                "type": "number"
+              },
+              "expected_slippage_pct": {
+                "type": "number"
+              },
+              "estimated_cost_or_proceeds": {
+                "type": "number"
+              },
+              "fillable": {
+                "type": "boolean"
+              },
+              "liquidity": {
+                "type": "number"
+              },
+              "fee_amount": {
+                "type": "number"
+              },
+              "tick_size": {
+                "type": "string"
+              }
+            }
+          },
+          "resolved": {
+            "type": "object",
+            "nullable": true,
+            "description": "Venue-native fields resolved from the catalog UUIDs (`venue`, `token_id`, `neg_risk`, `tick_size`).",
+            "properties": {
+              "venue": {
+                "type": "string",
+                "enum": [
+                  "polymarket",
+                  "opinion"
+                ]
+              },
+              "token_id": {
+                "type": "string"
+              },
+              "neg_risk": {
+                "type": "boolean"
+              },
+              "tick_size": {
+                "type": "number"
+              },
+              "opinion_market_id": {
+                "type": "integer",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "SubmitOrderHostedRequest": {
+        "type": "object",
+        "description": "Hosted submit-order request. `signature` is the local EIP-712 signature over `BuildOrderHostedResponse.typed_data`.",
+        "required": [
+          "built_order_id",
+          "signature"
+        ],
+        "properties": {
+          "built_order_id": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Hex-encoded EIP-712 signature."
+          },
+          "pull_signature": {
+            "type": "string",
+            "nullable": true,
+            "description": "Signature for the secondary pull-authorization, required when `pull_typed_data` was returned."
+          },
+          "wait": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, the server waits for on-chain settlement before responding."
+          }
+        }
+      },
+      "CancelBuildHostedRequest": {
+        "type": "object",
+        "required": [
+          "order_id",
+          "user_address"
+        ],
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "description": "Unified order id, as returned by `fetchOpenOrdersHosted`."
+          },
+          "user_address": {
+            "type": "string"
+          }
+        }
+      },
+      "CancelBuildHostedResponse": {
+        "type": "object",
+        "required": [
+          "cancel_id",
+          "typed_data",
+          "deadline"
+        ],
+        "properties": {
+          "cancel_id": {
+            "type": "string"
+          },
+          "typed_data": {
+            "type": "object"
+          },
+          "pull_typed_data": {
+            "type": "object",
+            "nullable": true
+          },
+          "deadline": {
+            "type": "integer",
+            "description": "Unix epoch (s) after which the cancel build expires."
+          }
+        }
+      },
+      "OrderV0": {
+        "type": "object",
+        "description": "Hosted-mode `Order` shape. Mirrors `pmxt.Order` so the SDK can return it directly. `tx_hash`, `chain`, and `block_number` populate once execution settles on-chain.",
+        "required": [
+          "id",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "market_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "outcome_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ],
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit"
+            ],
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "nullable": true
+          },
+          "filled": {
+            "type": "number"
+          },
+          "remaining": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "number",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "nullable": true
+          },
+          "tx_hash": {
+            "type": "string",
+            "nullable": true,
+            "description": "On-chain transaction hash. Null until settled."
+          },
+          "chain": {
+            "type": "string",
+            "nullable": true
+          },
+          "block_number": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "UserTradeV0": {
+        "type": "object",
+        "description": "Hosted-mode `UserTrade` shape. Mirrors `pmxt.UserTrade`.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "market_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "outcome_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ],
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "nullable": true
+          },
+          "fee": {
+            "type": "number",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "nullable": true
+          },
+          "tx_hash": {
+            "type": "string",
+            "nullable": true
+          },
+          "chain": {
+            "type": "string",
+            "nullable": true
+          },
+          "venue": {
+            "type": "string",
+            "enum": [
+              "polymarket",
+              "opinion"
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "PositionV0": {
+        "type": "object",
+        "description": "Hosted-mode `Position` shape. `current_price`, `current_value`, `entry_price`, `realized_pnl`, and `outcome_label` may be null when the server doesn't yet have the data.",
+        "required": [
+          "venue",
+          "shares"
+        ],
+        "properties": {
+          "market_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "outcome_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "venue": {
+            "type": "string",
+            "enum": [
+              "polymarket",
+              "opinion"
+            ]
+          },
+          "shares": {
+            "type": "number"
+          },
+          "current_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "current_value": {
+            "type": "number",
+            "nullable": true
+          },
+          "outcome_label": {
+            "type": "string",
+            "nullable": true
+          },
+          "entry_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "realized_pnl": {
+            "type": "number",
+            "nullable": true
+          }
+        }
+      },
+      "BalanceV0": {
+        "type": "object",
+        "description": "Hosted-mode `Balance` shape. Returns USDC held inside the PMXT `PreFundedEscrow` contract.",
+        "required": [
+          "currency",
+          "amount"
+        ],
+        "properties": {
+          "currency": {
+            "type": "string",
+            "default": "USDC"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "venue": {
+            "type": "string",
+            "enum": [
+              "polymarket",
+              "opinion"
+            ],
+            "nullable": true,
+            "description": "Set when the hosted backend returns a per-venue breakdown; null when balance is venue-agnostic."
           }
         }
       }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3309,162 +3309,162 @@
           {
             "lang": "python",
             "label": "Polymarket",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Polymarket(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n    signature_type=\"gnosis-safe\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Polymarket(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n    signature_type=\"gnosis-safe\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Kalshi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "KalshiDemo",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.KalshiDemo(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.KalshiDemo(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Opinion",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Smarkets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Smarkets(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Smarkets(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "PolymarketUs",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.create_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "javascript",
             "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Kalshi",
-            "source": "import { Kalshi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Kalshi({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Kalshi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Kalshi({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "KalshiDemo",
-            "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new KalshiDemo({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new KalshiDemo({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Smarkets({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Smarkets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Smarkets({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.createOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           }
         ]
       }
@@ -3541,162 +3541,162 @@
           {
             "lang": "python",
             "label": "Polymarket",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Polymarket(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n    signature_type=\"gnosis-safe\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Polymarket(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n    signature_type=\"gnosis-safe\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Limitless",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Limitless(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Kalshi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Kalshi(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "KalshiDemo",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.KalshiDemo(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.KalshiDemo(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Probable",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Probable(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n    passphrase=\"YOUR_PASSPHRASE\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Baozi",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Baozi(\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Myriad",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Myriad(\n    api_key=\"YOUR_API_KEY\",\n    wallet_address=\"YOUR_WALLET_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Opinion",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Opinion(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n    proxy_address=\"YOUR_PROXY_ADDRESS\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Metaculus",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Metaculus(\n    api_token=\"YOUR_API_TOKEN\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Smarkets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Smarkets(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Smarkets(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "PolymarketUs",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.PolymarketUs(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Hyperliquid",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Hyperliquid(\n    api_key=\"YOUR_API_KEY\",\n    private_key=\"YOUR_PRIVATE_KEY\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "GeminiTitan",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.GeminiTitan(\n    api_key=\"YOUR_API_KEY\",\n    api_secret=\"YOUR_API_SECRET\",\n)\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Suibets",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Suibets()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Mock",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Mock()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "python",
             "label": "Router",
-            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"market\",\n    amount=10,\n    price=0.55,\n    fee=1,\n    tick_size=1,\n    neg_risk=True,\n    on_behalf_of=1,\n)"
+            "source": "import pmxt\n\n# Runs locally — never proxied through PMXT servers\nexchange = pmxt.Router()\nresult = exchange.build_order(\n    market_id=\"12345\",\n    outcome_id=\"67890\",\n    side=\"buy\",\n    type=\"limit\",\n    amount=10,\n    price=0.55,\n)"
           },
           {
             "lang": "javascript",
             "label": "Polymarket",
-            "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Polymarket } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Polymarket({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n  signatureType: \"gnosis-safe\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Limitless",
-            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Limitless } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Limitless({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Kalshi",
-            "source": "import { Kalshi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Kalshi({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Kalshi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Kalshi({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "KalshiDemo",
-            "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new KalshiDemo({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { KalshiDemo } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new KalshiDemo({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Probable",
-            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Probable } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Probable({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n  passphrase: \"YOUR_PASSPHRASE\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Baozi",
-            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Baozi } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Baozi({\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Myriad",
-            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Myriad } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Myriad({\n  apiKey: \"YOUR_API_KEY\",\n  walletAddress: \"YOUR_WALLET_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Opinion",
-            "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Opinion } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Opinion({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n  proxyAddress: \"YOUR_PROXY_ADDRESS\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Metaculus",
-            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Metaculus } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Metaculus({\n  apiToken: \"YOUR_API_TOKEN\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Smarkets",
-            "source": "import { Smarkets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Smarkets({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Smarkets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Smarkets({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "PolymarketUs",
-            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { PolymarketUs } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new PolymarketUs({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Hyperliquid",
-            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Hyperliquid } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Hyperliquid({\n  apiKey: \"YOUR_API_KEY\",\n  privateKey: \"YOUR_PRIVATE_KEY\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "GeminiTitan",
-            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { GeminiTitan } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new GeminiTitan({\n  apiKey: \"YOUR_API_KEY\",\n  apiSecret: \"YOUR_API_SECRET\",\n});\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Suibets",
-            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Suibets } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Suibets();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Mock",
-            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Mock } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Mock();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           },
           {
             "lang": "javascript",
             "label": "Router",
-            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"market\",\n  amount: 10,\n  price: 0.55,\n  fee: 1,\n  tickSize: 1,\n  negRisk: true,\n  onBehalfOf: 1,\n});"
+            "source": "import { Router } from \"pmxtjs\";\n\n// Runs locally — never proxied through PMXT servers\nconst exchange = new Router();\nconst result = await exchange.buildOrder({\n  marketId: \"12345\",\n  outcomeId: \"67890\",\n  side: \"buy\",\n  type: \"limit\",\n  amount: 10,\n  price: 0.55,\n});"
           }
         ]
       }

--- a/docs/api-reference/submitOrder.mdx
+++ b/docs/api-reference/submitOrder.mdx
@@ -1,0 +1,134 @@
+---
+title: submitOrder
+description: Submit a previously-built order. Hosted requires a signed `built_order_id`.
+---
+
+<Tabs>
+  <Tab title="Hosted (recommended)">
+    <Note>
+      The hosted path routes to `POST trade.pmxt.dev/v0/trade/submit-order` and is
+      the default when `pmxt_api_key` is set. Pass the `built_order_id` from
+      [`buildOrder`](/api-reference/buildOrder) plus the local EIP-712 signature.
+      The order must be submitted before its `expiry`. See
+      [hosted trading](/concepts/hosted-trading) and the [signing guide](/guides/signing).
+      Get a key at [pmxt.dev/dashboard](https://pmxt.dev/dashboard).
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        pmxt_api_key="YOUR_PMXT_API_KEY",
+        wallet_address="0xYourWallet",
+        private_key="0x...",
+    )
+    built = client.build_order(
+        market_id="12345678-1234-1234-1234-123456789abc",
+        outcome_id="abcdef01-2345-6789-abcd-ef0123456789",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    order = client.submit_order(built)
+    print(order.id, order.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      pmxtApiKey: "YOUR_PMXT_API_KEY",
+      walletAddress: "0xYourWallet",
+      privateKey: "0x...",
+    });
+
+    const built = await client.buildOrder({
+      marketId: "12345678-1234-1234-1234-123456789abc",
+      outcomeId: "abcdef01-2345-6789-abcd-ef0123456789",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    const order = await client.submitOrder(built);
+    console.log(order.id, order.status);
+    ```
+
+    ```bash curl
+    curl -X POST "https://trade.pmxt.dev/v0/trade/submit-order" \
+      -H "Authorization: Bearer $PMXT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "built_order_id": "blt_abc123...",
+        "signature": "0x...",
+        "wait": false
+      }'
+    ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Self-hosted">
+    <Note>
+      The self-hosted path uses the local sidecar at
+      `POST localhost:3847/api/{exchange}/submitOrder`. The sidecar signs locally
+      against the venue's CLOB; the request body contains the venue-native built
+      order returned by [`buildOrder`](/api-reference/buildOrder). See
+      [Self-hosted](/guides/self-hosted) for setup.
+    </Note>
+
+    <CodeGroup>
+    ```python Python
+    import pmxt
+
+    client = pmxt.Polymarket(
+        api_key="YOUR_VENUE_API_KEY",
+        api_secret="YOUR_VENUE_API_SECRET",
+        passphrase="YOUR_PASSPHRASE",
+        private_key="YOUR_PRIVATE_KEY",
+        proxy_address="YOUR_PROXY_ADDRESS",
+    )
+    built = client.build_order(
+        market_id="12345",
+        outcome_id="67890",
+        side="buy",
+        type="limit",
+        amount=10,
+        price=0.55,
+    )
+    order = client.submit_order(built)
+    print(order.id, order.status)
+    ```
+
+    ```javascript TypeScript
+    import { Polymarket } from "pmxtjs";
+
+    const client = new Polymarket({
+      apiKey: "YOUR_VENUE_API_KEY",
+      apiSecret: "YOUR_VENUE_API_SECRET",
+      passphrase: "YOUR_PASSPHRASE",
+      privateKey: "YOUR_PRIVATE_KEY",
+      proxyAddress: "YOUR_PROXY_ADDRESS",
+    });
+
+    const built = await client.buildOrder({
+      marketId: "12345",
+      outcomeId: "67890",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.55,
+    });
+    const order = await client.submitOrder(built);
+    console.log(order.id, order.status);
+    ```
+
+    ```bash curl
+    curl -X POST "http://localhost:3847/api/polymarket/submitOrder" \
+      -H "Content-Type: application/json" \
+      -d '{"args":[{"exchange":"polymarket","raw":{...}}]}'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -172,23 +172,23 @@
           {
             "group": "Trading",
             "pages": [
-              "POST /api/{exchange}/createOrder",
-              "POST /api/{exchange}/buildOrder",
-              "POST /api/{exchange}/submitOrder",
-              "POST /api/{exchange}/cancelOrder"
+              "api-reference/createOrder",
+              "api-reference/buildOrder",
+              "api-reference/submitOrder",
+              "api-reference/cancelOrder"
             ],
             "openapi": "api-reference/openapi.json"
           },
           {
             "group": "Orders & Positions",
             "pages": [
-              "GET /api/{exchange}/fetchOrder",
-              "GET /api/{exchange}/fetchOpenOrders",
-              "GET /api/{exchange}/fetchMyTrades",
-              "GET /api/{exchange}/fetchClosedOrders",
-              "GET /api/{exchange}/fetchAllOrders",
-              "GET /api/{exchange}/fetchPositions",
-              "GET /api/{exchange}/fetchBalance"
+              "api-reference/fetchOrder",
+              "api-reference/fetchOpenOrders",
+              "api-reference/fetchMyTrades",
+              "api-reference/fetchClosedOrders",
+              "api-reference/fetchAllOrders",
+              "api-reference/fetchPositions",
+              "api-reference/fetchBalance"
             ],
             "openapi": "api-reference/openapi.json"
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -176,8 +176,7 @@
               "api-reference/buildOrder",
               "api-reference/submitOrder",
               "api-reference/cancelOrder"
-            ],
-            "openapi": "api-reference/openapi.json"
+            ]
           },
           {
             "group": "Orders & Positions",
@@ -189,8 +188,7 @@
               "api-reference/fetchAllOrders",
               "api-reference/fetchPositions",
               "api-reference/fetchBalance"
-            ],
-            "openapi": "api-reference/openapi.json"
+            ]
           },
           {
             "group": "Realtime",


### PR DESCRIPTION
Follow-up to v2.49.1. Adds a synchronized `Hosted (recommended)` / `Self-hosted` tab toggle to every Group A method reference page so customers see the hosted endpoint and v2.49 SDK constructor shape by default, and can flip to the local-sidecar variant in place. Mintlify syncs tab selection across pages via shared label keys.

## What's in this PR

**11 shadow MDX files** (`docs/api-reference/{buildOrder,cancelOrder,createOrder,fetchAllOrders,fetchBalance,fetchClosedOrders,fetchMyTrades,fetchOpenOrders,fetchOrder,fetchPositions,submitOrder}.mdx`) — each wraps the existing OpenAPI auto-render in a `<Tabs>` toggle. Tab labels byte-identical across all 11 files for cross-page sync.

**9 new operations in `openapi-hosted.json`** documenting `trade.pmxt.dev/v0/*`: buildOrderHosted, submitOrderHosted, createOrderHosted, cancelOrderHosted, fetchBalanceHosted, fetchPositionsHosted, fetchOpenOrdersHosted, fetchMyTradesHosted, fetchOrderHosted. Each with Python + TypeScript `x-codeSamples`, error coverage 401/403/404/410/422/503, bearer auth.

**10 new component schemas** for the v0 request/response shapes, reusing existing components from 2.49.1.

**`docs.json`** updated so Trading + Orders & Positions sidebar groups point at the shadow MDX slugs.

**JSDoc rot fix**: `createOrder` / `buildOrder` code samples used to show `type="market"` with `price=0.55` (incoherent — price is limit-only). Replaced with coherent limit samples across all 16 venues via `PARAM_OVERRIDES` in the generator.

**Changelog 2.49.2 entry** added.

## Not addressed (flagged in changelog)

- `fetchClosedOrdersHosted` / `fetchAllOrdersHosted` raise `NotSupported` in hosted mode (no underlying endpoint). Shadow MDX surfaces this via `<Warning>` linking to `fetchMyTrades`.
- Escrow methods are hosted-only, not in Group A scope. Future PR.
- Generator capability-map gap (Hyperliquid/GeminiTitan/Mock missing). Future PR.

## Test plan
- [ ] Mintlify preview renders all 11 toggle pages
- [ ] Click `Self-hosted` on `createOrder` → navigate to `fetchBalance` → confirm Self-hosted tab is still active (sync)
- [ ] Confirm Hosted tab is active by default on first load
- [ ] No regressions on existing OpenAPI-auto-rendered pages outside Group A