### PR TITLE
fix(ts-sdk): send auth headers for execution price details

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -2691,7 +2691,7 @@ export abstract class Exchange {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    ...this.config.headers
+                    ...this.getAuthHeaders()
                 },
                 body: JSON.stringify(body)
             });

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -137,6 +137,25 @@ describe("hosted read dispatch", () => {
     expect(reqs[0].url).toContain("/v0/orders/abc");
     expect(reqs[0].init?.method).toBe("GET");
   });
+
+  it("getExecutionPriceDetailed sends hosted bearer auth header", async () => {
+    const spy = installFetchSpy(() =>
+      jsonResponse({
+        success: true,
+        data: { price: 0.51, total: 5.1, slippage: 0, fills: [] },
+      }),
+    );
+    const api = makePolymarket();
+
+    await api.getExecutionPriceDetailed({ bids: [], asks: [] } as any, "buy", 10);
+
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toContain("/api/polymarket/getExecutionPriceDetailed");
+    expect(reqs[0].init?.method).toBe("POST");
+    const headers = reqs[0].init?.headers as Record<string, string> | undefined;
+    expect(headers?.Authorization).toBe(`Bearer ${PMXT_API_KEY}`);
+  });
 });
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update TypeScript getExecutionPriceDetailed to use getAuthHeaders(), matching other authenticated SDK calls
- Add a hosted dispatch regression test asserting the bearer auth header is sent

Fixes #931

## Test Plan
- RED: added focused Jest test and confirmed it failed because Authorization was missing
- GREEN: npm test -- --runInBand tests/hosted-dispatch.test.ts -t 'getExecutionPriceDetailed sends hosted bearer auth header'
- npm test -- --runInBand tests/hosted-dispatch.test.ts

Note: local test bootstrap required temporary ignored generated OpenAPI stubs because this runner lacks Java for the generator; committed changes are only client/test files.