### PR TITLE
fix(python-sdk): export NotSupported at package root

### DIFF
--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -39,6 +39,7 @@ from .errors import (
     ValidationError,
     NetworkError,
     ExchangeNotAvailable,
+    NotSupported,
 )
 from .models import (
     UnifiedMarket,
@@ -216,6 +217,7 @@ __all__ = [
     "ValidationError",
     "NetworkError",
     "ExchangeNotAvailable",
+    "NotSupported",
     # Data Models
     "UnifiedMarket",
     "UnifiedEvent",


### PR DESCRIPTION
## Summary
- Re-export `NotSupported` from the Python package root
- Include `NotSupported` in `pmxt.__all__` for parity with the TypeScript SDK package exports

Fixes #985

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/__init__.py sdks/python/pmxt/errors.py`
- Static export smoke: verified `NotSupported` import and `__all__` entries in `sdks/python/pmxt/__init__.py`
- Runtime `import pmxt` is blocked in this checkout by missing generated `pmxt_internal`, so no package import smoke was run.