### PR TITLE
fix(ts-sdk): align structural model metadata fields

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -232,6 +232,15 @@ export interface UserTrade {
 
     /** On-chain block number where this trade was included. Populated in hosted mode. */
     blockNumber?: number;
+
+    /** Trading fee, when available. */
+    fee?: number;
+
+    /** Venue that produced this trade, when available. */
+    venue?: string;
+
+    /** Raw venue-specific payload, when available. */
+    raw?: unknown;
 }
 
 /**
@@ -336,6 +345,9 @@ export interface Order {
 
     /** On-chain block number where this order was included. Populated in hosted mode. */
     blockNumber?: number;
+
+    /** Raw venue-specific payload, when available. */
+    raw?: unknown;
 }
 
 /**
@@ -374,6 +386,15 @@ export interface Position {
 
     /** On-chain block number for the latest position update. Populated in hosted mode. */
     blockNumber?: number;
+
+    /** Venue that produced this position, when available. */
+    venue?: string;
+
+    /** Current mark-to-market value, when available. */
+    currentValue?: number;
+
+    /** Raw venue-specific payload, when available. */
+    raw?: unknown;
 }
 
 /**
@@ -400,6 +421,9 @@ export interface Balance {
 
     /** On-chain block number for the latest balance update. Populated in hosted mode. */
     blockNumber?: number;
+
+    /** Venue or hosted account source, when available. */
+    venue?: string;
 }
 
 // Parameter types


### PR DESCRIPTION
## Summary
- Add TypeScript SDK structural metadata fields already present in Python models: `fee`/`venue`/`raw` on `UserTrade`, `raw` on `Order`, `venue`/`currentValue`/`raw` on `Position`, and `venue` on `Balance`
- Keeps the change type-only and backwards-compatible; no runtime trading behavior changes

Fixes #986
Fixes #987
Fixes #988
Fixes #989

## Test Plan
- `git diff --check`
- `npx tsc --noEmit --skipLibCheck --target es2020 --module commonjs sdks/typescript/pmxt/models.ts`
- Full `npx tsc --noEmit -p sdks/typescript/tsconfig.json` is blocked in this checkout by missing generated `../generated/src/index.js`, unrelated to this model-only change.