### PR TITLE
fix(sdk): preserve hosted client generator overrides

### DIFF
--- a/sdks/python/API_REFERENCE.md
+++ b/sdks/python/API_REFERENCE.md
@@ -1443,6 +1443,25 @@ for pos in positions:
 
 ## Data Models
 
+### `ExchangeOptions`
+
+Constructor-level options for venue clients (Polymarket, Kalshi, Opinion, etc.).
+Hosted mode is the default when pmxtApiKey is set; otherwise the SDK runs against
+a local sidecar with venue credentials.
+
+```python
+@dataclass
+class ExchangeOptions:
+pmxt_api_key: str # PMXT customer API key. When set, the SDK routes to api.pmxt.dev (catalog) and trade.pmxt.dev (trading). Get one at pmxt.dev/dashboard.
+wallet_address: str # EVM wallet address for hosted reads/writes. Required for endpoints that operate on a wallet (balances, positions, trades, open orders).
+signer: object # Optional pre-built signer for hosted writes. If absent and privateKey is set, the SDK auto-wraps privateKey into a signer.
+private_key: str # Private key. In hosted mode, used to derive an EIP-712 signer for writes (wraps into EthAccountSigner/EthersSigner). In self-hosted mode, used as the venue credential directly.
+base_url: str # Explicit base URL override. When unset, the SDK uses api.pmxt.dev when pmxtApiKey is set, or the local sidecar otherwise.
+api_key: str # Venue-side API key (e.g. Polymarket CLOB key). Only relevant for self-hosted mode.
+auto_start_server: bool # Auto-start the local sidecar when running self-hosted. Defaults to true when no pmxtApiKey is set, false when hosted.
+```
+
+---
 ### `UnifiedMarket`
 
 
@@ -1527,11 +1546,11 @@ id: str # Stable venue-native series identifier (e.g. "KXATPMATCH" on Kalshi, "a
 ticker: str # Venue-native ticker, when distinct from `id`.
 slug: str # Venue-native slug.
 title: str # Human-readable series title (e.g. "ATP Match Winner", "WTA").
-description: Any # Long-form series description.
-recurrence: Any # Recurrence cadence the venue reports ('daily', 'weekly', 'annual', ...).
+description: str # Long-form series description.
+recurrence: str # Recurrence cadence the venue reports ('daily', 'weekly', 'annual', ...).
 events: List[UnifiedEvent] # Child events. Populated when fetched by id; the list form usually omits this to keep payloads small.
-url: Any # Canonical venue URL for the series.
-image: Any # Venue-hosted image.
+url: str # Canonical venue URL for the series.
+image: str # Venue-hosted image.
 source_exchange: str # The exchange this series originates from. Populated by the Router.
 source_metadata: object # Raw venue-specific fields not promoted to first-class columns.
 ```
@@ -1613,6 +1632,9 @@ amount: float # Size of the trade in contracts/shares.
 side: str # Trade side from the taker's perspective.
 outcome_id: str # The outcome this trade is for (if known).
 order_id: str # The order that produced this trade, if known.
+tx_hash: str # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+chain: str # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+block_number: float # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
 ```
 
 ---
@@ -1637,24 +1659,31 @@ remaining: float # Amount remaining
 timestamp: float # Unix timestamp in milliseconds when the order was created.
 fee: float # Fee paid for this order, if known.
 fee_rate_bps: float # Fee rate in basis points applied to this order (e.g. 100 = 1%).
+tx_hash: str # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+chain: str # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+block_number: float # Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
 ```
 
 ---
 ### `Position`
 
-
+A current position in a market. In hosted mode, `outcomeLabel`, `entryPrice`, `currentPrice` and `unrealizedPnL` may be null when the server cannot derive them (e.g. `with_mtm=false` or no fill history). Venue-direct callers continue to populate every field.
 
 ```python
 @dataclass
 class Position:
 market_id: str # The market this position is held in.
 outcome_id: str # The outcome this position is held in.
-outcome_label: str # Human-readable label for the outcome held.
+outcome_label: str # Human-readable label for the outcome held. Optional in hosted mode.
 size: float # Positive for long, negative for short
-entry_price: float # Average entry price for the position (probability between 0.0 and 1.0).
-current_price: float # Current mark price for the position (probability between 0.0 and 1.0).
-unrealized_pnl: float # Unrealized profit or loss at the current price (USD).
+entry_price: float # Average entry price for the position (probability between 0.0 and 1.0). Optional in hosted mode when no fill history is available.
+current_price: float # Current mark price for the position (probability between 0.0 and 1.0). Optional in hosted mode when mark-to-market data is unavailable.
+current_value: float # Current market value of the position (size * currentPrice). Null when currentPrice is unavailable.
+unrealized_pnl: float # Unrealized profit or loss at the current price (USD). Optional in hosted mode when mark-to-market data is unavailable.
 realized_pnl: float # Realized profit or loss booked so far (USD).
+tx_hash: str # Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
+chain: str # Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
+block_number: float # Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
 ```
 
 ---
@@ -1669,6 +1698,7 @@ currency: str # e.g., 'USDC'
 total: float # Total balance including funds locked in open orders.
 available: float # Balance available to trade (excludes locked funds).
 locked: float # In open orders
+venue: str # Hosted-mode: which venue this balance belongs to in a multi-venue response. Null when the balance is venue-agnostic.
 ```
 
 ---
@@ -1723,6 +1753,7 @@ params: Any # The original params used to build this order.
 signed_order: object # For CLOB exchanges (Polymarket): the EIP-712 signed order ready to POST to the exchange's order endpoint.
 tx: object # For on-chain AMM exchanges: the EVM transaction payload. Reserved for future exchanges; no current exchange populates this.
 raw: Any # The raw, exchange-native payload. Always present.
+expiry: float # Unix epoch (ms) when this built order expires server-side. Submitting after expiry returns BUILT_ORDER_EXPIRED.
 ```
 
 ---
@@ -1774,9 +1805,9 @@ market: UnifiedMarket #
 source_market: Any # The source market this was matched against. Present in browse mode (no marketId), absent in lookup mode.
 relation: str # 
 confidence: float # 
-reasoning: Any # 
-best_bid: Any # 
-best_ask: Any # 
+reasoning: str # 
+best_bid: float # 
+best_ask: float # 
 ```
 
 ---
@@ -1802,9 +1833,9 @@ class PriceComparison:
 market: UnifiedMarket # 
 relation: str # 
 confidence: float # 
-reasoning: Any # 
-best_bid: Any # 
-best_ask: Any # 
+reasoning: str # 
+best_bid: float # 
+best_ask: float # 
 venue: str # 
 ```
 
@@ -1844,7 +1875,7 @@ price_a: float #
 price_b: float # 
 relation: str # The set-theoretic relation between the two markets (e.g. identity, subset).
 confidence: float # Match confidence score (0.0 to 1.0).
-reasoning: Any # Why the two markets were matched.
+reasoning: str # Why the two markets were matched.
 ```
 
 ---

--- a/sdks/python/scripts/generate-client-methods.js
+++ b/sdks/python/scripts/generate-client-methods.js
@@ -45,6 +45,22 @@ const SKIP_GENERATE = new Set([
     'filterEvents',              // pure local computation, no sidecar
 ]);
 
+// Hosted-mode trading/read methods carry hand-maintained dispatch in client.py.
+// Keep these sections inside the generated region stable when regenerating the
+// sidecar pass-through surface from BaseExchange.ts. Without this preservation,
+// a focused SDK/doc PR that runs this generator drops hosted-mode guards/helpers
+// unrelated to the PR and fails generated-sync checks with broad drift.
+const PRESERVE_GENERATED_METHODS = [
+    'cancel_order',
+    'fetch_order',
+    'fetch_open_orders',
+    'fetch_my_trades',
+    'fetch_closed_orders',
+    'fetch_all_orders',
+    'fetch_positions',
+    'fetch_balance',
+];
+
 // ---------------------------------------------------------------------------
 // TypeScript type name -> Python type info
 //
@@ -475,6 +491,54 @@ function generatePyMethod(name, params, config, sf) {
     ].join('\n');
 }
 
+function extractGeneratedRegion(client) {
+    const beginIdx = client.indexOf(MARKER_BEGIN);
+    const endIdx = client.indexOf(MARKER_END);
+    if (beginIdx === -1 || endIdx === -1 || endIdx <= beginIdx) return '';
+    return client.slice(beginIdx + MARKER_BEGIN.length, endIdx);
+}
+
+function methodPrefix(methodName) {
+    return `    def ${methodName}(`;
+}
+
+function findMethodSegment(region, methodName) {
+    const start = region.indexOf(methodPrefix(methodName));
+    if (start === -1) return null;
+
+    const nextDef = region.indexOf('\n    def ', start + methodPrefix(methodName).length);
+    const end = nextDef === -1 ? region.length : nextDef + 1;
+    return region.slice(start, end).replace(/\n+$/u, '');
+}
+
+function replaceMethodSegment(region, methodName, replacement) {
+    const start = region.indexOf(methodPrefix(methodName));
+    if (start === -1) {
+        throw new Error(`Generated ${methodName} not found while preserving hosted overrides`);
+    }
+
+    const nextDef = region.indexOf('\n    def ', start + methodPrefix(methodName).length);
+    const end = nextDef === -1 ? region.length : nextDef + 1;
+    return `${region.slice(0, start)}${replacement}\n\n${region.slice(end).replace(/^\n+/u, '')}`;
+}
+
+function preserveHostedMethodOverrides(existingClient, generated) {
+    const existingRegion = extractGeneratedRegion(existingClient);
+    let nextGenerated = generated;
+
+    for (const methodName of PRESERVE_GENERATED_METHODS) {
+        const existingSegment = findMethodSegment(existingRegion, methodName);
+        if (!existingSegment) continue;
+
+        // Only preserve methods that actually contain hosted-mode dispatch. This
+        // avoids freezing unrelated generated methods if the source file changes.
+        if (!existingSegment.includes('self.is_hosted')) continue;
+        nextGenerated = replaceMethodSegment(nextGenerated, methodName, existingSegment);
+    }
+
+    return nextGenerated;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -485,13 +549,14 @@ function main() {
 
     const methods = extractMethods(sf);
 
-    const generated = methods.map(m => {
+    let generated = methods.map(m => {
         const name = m.name.text;
         const config = inferReturnConfig(m.type, name, sf);
         return generatePyMethod(name, m.parameters, config, sf);
     }).join('\n\n');
 
     let client = fs.readFileSync(CLIENT_PATH, 'utf-8');
+    generated = preserveHostedMethodOverrides(client, generated);
 
     const beginIdx = client.indexOf(MARKER_BEGIN);
     const endIdx = client.indexOf(MARKER_END);

--- a/sdks/typescript/API_REFERENCE.md
+++ b/sdks/typescript/API_REFERENCE.md
@@ -1444,6 +1444,25 @@ positions.forEach(pos => {
 
 ## Data Models
 
+### `ExchangeOptions`
+
+Constructor-level options for venue clients (Polymarket, Kalshi, Opinion, etc.).
+Hosted mode is the default when pmxtApiKey is set; otherwise the SDK runs against
+a local sidecar with venue credentials.
+
+```typescript
+interface ExchangeOptions {
+pmxtApiKey: string; // PMXT customer API key. When set, the SDK routes to api.pmxt.dev (catalog) and trade.pmxt.dev (trading). Get one at pmxt.dev/dashboard.
+walletAddress: string; // EVM wallet address for hosted reads/writes. Required for endpoints that operate on a wallet (balances, positions, trades, open orders).
+signer: object; // Optional pre-built signer for hosted writes. If absent and privateKey is set, the SDK auto-wraps privateKey into a signer.
+privateKey: string; // Private key. In hosted mode, used to derive an EIP-712 signer for writes (wraps into EthAccountSigner/EthersSigner). In self-hosted mode, used as the venue credential directly.
+baseUrl: string; // Explicit base URL override. When unset, the SDK uses api.pmxt.dev when pmxtApiKey is set, or the local sidecar otherwise.
+apiKey: string; // Venue-side API key (e.g. Polymarket CLOB key). Only relevant for self-hosted mode.
+autoStartServer: boolean; // Auto-start the local sidecar when running self-hosted. Defaults to true when no pmxtApiKey is set, false when hosted.
+}
+```
+
+---
 ### `UnifiedMarket`
 
 
@@ -1527,11 +1546,11 @@ id: string; // Stable venue-native series identifier (e.g. "KXATPMATCH" on Kalsh
 ticker: string; // Venue-native ticker, when distinct from `id`.
 slug: string; // Venue-native slug.
 title: string; // Human-readable series title (e.g. "ATP Match Winner", "WTA").
-description: any; // Long-form series description.
-recurrence: any; // Recurrence cadence the venue reports ('daily', 'weekly', 'annual', ...).
+description: string; // Long-form series description.
+recurrence: string; // Recurrence cadence the venue reports ('daily', 'weekly', 'annual', ...).
 events: UnifiedEvent[]; // Child events. Populated when fetched by id; the list form usually omits this to keep payloads small.
-url: any; // Canonical venue URL for the series.
-image: any; // Venue-hosted image.
+url: string; // Canonical venue URL for the series.
+image: string; // Venue-hosted image.
 sourceExchange: string; // The exchange this series originates from. Populated by the Router.
 sourceMetadata: object; // Raw venue-specific fields not promoted to first-class columns.
 }
@@ -1613,6 +1632,9 @@ amount: number; // Size of the trade in contracts/shares.
 side: string; // Trade side from the taker's perspective.
 outcomeId: string; // The outcome this trade is for (if known).
 orderId: string; // The order that produced this trade, if known.
+txHash: string; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+chain: string; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+blockNumber: number; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
 }
 ```
 
@@ -1637,24 +1659,31 @@ remaining: number; // Amount remaining
 timestamp: number; // Unix timestamp in milliseconds when the order was created.
 fee: number; // Fee paid for this order, if known.
 feeRateBps: number; // Fee rate in basis points applied to this order (e.g. 100 = 1%).
+txHash: string; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+chain: string; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
+blockNumber: number; // Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues.
 }
 ```
 
 ---
 ### `Position`
 
-
+A current position in a market. In hosted mode, `outcomeLabel`, `entryPrice`, `currentPrice` and `unrealizedPnL` may be null when the server cannot derive them (e.g. `with_mtm=false` or no fill history). Venue-direct callers continue to populate every field.
 
 ```typescript
 interface Position {
 marketId: string; // The market this position is held in.
 outcomeId: string; // The outcome this position is held in.
-outcomeLabel: string; // Human-readable label for the outcome held.
+outcomeLabel: string; // Human-readable label for the outcome held. Optional in hosted mode.
 size: number; // Positive for long, negative for short
-entryPrice: number; // Average entry price for the position (probability between 0.0 and 1.0).
-currentPrice: number; // Current mark price for the position (probability between 0.0 and 1.0).
-unrealizedPnL: number; // Unrealized profit or loss at the current price (USD).
+entryPrice: number; // Average entry price for the position (probability between 0.0 and 1.0). Optional in hosted mode when no fill history is available.
+currentPrice: number; // Current mark price for the position (probability between 0.0 and 1.0). Optional in hosted mode when mark-to-market data is unavailable.
+currentValue: number; // Current market value of the position (size * currentPrice). Null when currentPrice is unavailable.
+unrealizedPnL: number; // Unrealized profit or loss at the current price (USD). Optional in hosted mode when mark-to-market data is unavailable.
 realizedPnL: number; // Realized profit or loss booked so far (USD).
+txHash: string; // Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
+chain: string; // Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
+blockNumber: number; // Populated in hosted mode after on-chain settlement (from the last fill); null for local-mode and for non-on-chain venues.
 }
 ```
 
@@ -1669,6 +1698,7 @@ currency: string; // e.g., 'USDC'
 total: number; // Total balance including funds locked in open orders.
 available: number; // Balance available to trade (excludes locked funds).
 locked: number; // In open orders
+venue: string; // Hosted-mode: which venue this balance belongs to in a multi-venue response. Null when the balance is venue-agnostic.
 }
 ```
 
@@ -1723,6 +1753,7 @@ params: any; // The original params used to build this order.
 signedOrder: object; // For CLOB exchanges (Polymarket): the EIP-712 signed order ready to POST to the exchange's order endpoint.
 tx: object; // For on-chain AMM exchanges: the EVM transaction payload. Reserved for future exchanges; no current exchange populates this.
 raw: any; // The raw, exchange-native payload. Always present.
+expiry: number; // Unix epoch (ms) when this built order expires server-side. Submitting after expiry returns BUILT_ORDER_EXPIRED.
 }
 ```
 
@@ -1774,9 +1805,9 @@ market: UnifiedMarket; //
 sourceMarket: any; // The source market this was matched against. Present in browse mode (no marketId), absent in lookup mode.
 relation: string; // 
 confidence: number; // 
-reasoning: any; // 
-bestBid: any; // 
-bestAsk: any; // 
+reasoning: string; // 
+bestBid: number; // 
+bestAsk: number; // 
 }
 ```
 
@@ -1802,9 +1833,9 @@ interface PriceComparison {
 market: UnifiedMarket; // 
 relation: string; // 
 confidence: number; // 
-reasoning: any; // 
-bestBid: any; // 
-bestAsk: any; // 
+reasoning: string; // 
+bestBid: number; // 
+bestAsk: number; // 
 venue: string; // 
 }
 ```
@@ -1844,7 +1875,7 @@ priceA: number; //
 priceB: number; // 
 relation: string; // The set-theoretic relation between the two markets (e.g. identity, subset).
 confidence: number; // Match confidence score (0.0 to 1.0).
-reasoning: any; // Why the two markets were matched.
+reasoning: string; // Why the two markets were matched.
 }
 ```
 

--- a/sdks/typescript/scripts/generate-client-methods.js
+++ b/sdks/typescript/scripts/generate-client-methods.js
@@ -43,6 +43,23 @@ const SKIP_GENERATE = new Set([
     'filterEvents',              // pure local computation, no sidecar
 ]);
 
+// Hosted-mode trading/read methods carry hand-maintained dispatch in client.ts.
+// Keep these sections inside the generated region stable when regenerating the
+// sidecar pass-through surface from BaseExchange.ts. Without this preservation,
+// a focused SDK/doc PR that runs this generator drops hosted-mode guards/helpers
+// unrelated to the PR and fails generated-sync checks with broad drift.
+const PRESERVE_GENERATED_METHODS = [
+    'submitOrder',
+    'cancelOrder',
+    'fetchOrder',
+    'fetchOpenOrders',
+    'fetchMyTrades',
+    'fetchClosedOrders',
+    'fetchAllOrders',
+    'fetchPositions',
+    'fetchBalance',
+];
+
 // ---------------------------------------------------------------------------
 // TypeScript type name -> SDK type info
 //
@@ -460,6 +477,54 @@ function generateMethod(name, params, config, sf) {
     ].join('\n');
 }
 
+function extractGeneratedRegion(client) {
+    const beginIdx = client.indexOf(MARKER_BEGIN);
+    const endIdx = client.indexOf(MARKER_END);
+    if (beginIdx === -1 || endIdx === -1 || endIdx <= beginIdx) return '';
+    return client.slice(beginIdx + MARKER_BEGIN.length, endIdx);
+}
+
+function methodPrefix(methodName) {
+    return `    async ${methodName}(`;
+}
+
+function findMethodSegment(region, methodName) {
+    const start = region.indexOf(methodPrefix(methodName));
+    if (start === -1) return null;
+
+    const nextMethod = region.indexOf('\n    async ', start + methodPrefix(methodName).length);
+    const end = nextMethod === -1 ? region.length : nextMethod + 1;
+    return region.slice(start, end).replace(/\n+$/u, '');
+}
+
+function replaceMethodSegment(region, methodName, replacement) {
+    const start = region.indexOf(methodPrefix(methodName));
+    if (start === -1) {
+        throw new Error(`Generated ${methodName} not found while preserving hosted overrides`);
+    }
+
+    const nextMethod = region.indexOf('\n    async ', start + methodPrefix(methodName).length);
+    const end = nextMethod === -1 ? region.length : nextMethod + 1;
+    return `${region.slice(0, start)}${replacement}\n\n${region.slice(end).replace(/^\n+/u, '')}`;
+}
+
+function preserveHostedMethodOverrides(existingClient, generated) {
+    const existingRegion = extractGeneratedRegion(existingClient);
+    let nextGenerated = generated;
+
+    for (const methodName of PRESERVE_GENERATED_METHODS) {
+        const existingSegment = findMethodSegment(existingRegion, methodName);
+        if (!existingSegment) continue;
+
+        // Only preserve methods that actually contain hosted-mode dispatch. This
+        // avoids freezing unrelated generated methods if the source file changes.
+        if (!existingSegment.includes('isHostedTradingMode()')) continue;
+        nextGenerated = replaceMethodSegment(nextGenerated, methodName, existingSegment);
+    }
+
+    return nextGenerated;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -470,13 +535,14 @@ function main() {
 
     const methods = extractMethods(sf);
 
-    const generated = methods.map(m => {
+    let generated = methods.map(m => {
         const name = m.name.text;
         const config = inferReturnConfig(m.type, name, sf);
         return generateMethod(name, m.parameters, config, sf);
     }).join('\n\n');
 
     let client = fs.readFileSync(CLIENT_PATH, 'utf-8');
+    generated = preserveHostedMethodOverrides(client, generated);
 
     const beginIdx = client.indexOf(MARKER_BEGIN);
     const endIdx = client.indexOf(MARKER_END);


### PR DESCRIPTION
## Summary
- Fixes the central Python and TypeScript client method generators so hosted-mode dispatch/helper sections inside the generated client regions are preserved on regeneration.
- Prevents focused SDK/doc PRs from having generated-client checks remove unrelated hosted-mode submit/cancel/read helpers.
- Syncs generated Python/TypeScript API references after `npm run generate:docs --workspace=pmxt-core` so the API reference check is clean.

## Unblocks
- #956
- #963
- #997
- #998
- #999
- #1000
- #1001

## Investigation
- The failing `Verify client.py methods are up-to-date` / `Verify client.ts methods are up-to-date` jobs regenerate the client method blocks from `BaseExchange.ts`.
- Current generators treated the whole generated region as purely templated sidecar pass-through code, but the checked-in clients also contain hand-maintained hosted-mode dispatch in that region:
  - Python: `cancel_order`, `fetch_order`, `fetch_open_orders`, `fetch_my_trades`, `fetch_closed_orders`, `fetch_all_orders`, `fetch_positions`, `fetch_balance`.
  - TypeScript: `submitOrder`, `cancelOrder`, `fetchOrder`, `fetchOpenOrders`, `fetchMyTrades`, `fetchClosedOrders`, `fetchAllOrders`, `fetchPositions`, `fetchBalance`.
- Before this fix, rerunning the generators deleted those hosted-mode guards/private helpers, causing broad unrelated drift in focused PRs.
- The API reference check was also stale against source model docs/types; this PR includes only the generated Python/TypeScript API reference files checked by that workflow.

## Validation
- `node --check sdks/python/scripts/generate-client-methods.js`
- `node --check sdks/typescript/scripts/generate-client-methods.js`
- `node sdks/python/scripts/generate-client-methods.js`
- `node sdks/typescript/scripts/generate-client-methods.js`
- `git diff --exit-code -- sdks/python/pmxt/client.py sdks/typescript/pmxt/client.ts`
- `npm run generate:docs --workspace=pmxt-core`
- `python3 -m py_compile sdks/python/pmxt/client.py sdks/python/pmxt/_hosted_routing.py sdks/python/pmxt/models.py`
- `npm run build --workspace=pmxt-core`

## Commands run but not committed
- `npm run generate:openapi --workspace=pmxt-core` was tried before and after `npm run build --workspace=pmxt-core`; it produced broad OpenAPI/version/scope drift unrelated to this fix, so generated OpenAPI files were reset.
- `python3 -m pytest -q sdks/python/tests/test_hosted_dispatch.py` could not run because `pytest` is not installed in this environment.
- `npm test --workspace=pmxtjs -- --runTestsByPath tests/hosted-dispatch.test.ts` and `npm run build --workspace=pmxtjs` could not run because `sdks/typescript/generated/src/index.js` is absent.
- `npm run generate:sdk:typescript --workspace=pmxt-core` could not generate the missing TS SDK because Java is not installed.
