### PR TITLE
fix(ts-sdk): route hosted order book reads

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -63,6 +63,7 @@ import { logger } from "./logger.js";
 // once the matching files exist.
 import {
     HOSTED_TRADING_VENUES,
+    HOSTED_CATALOG_BASE_URL,
     _tradingRequest,
     resolveWalletAddress,
     ensureHostedTradingSupported,
@@ -1076,7 +1077,11 @@ export abstract class Exchange {
                 if (limit === undefined) args.push(null);
                 args.push(params);
             }
-            const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/fetchOrderBook`, {
+            const route = this.pmxtApiKey ? HOSTED_METHOD_ROUTES.get("fetchOrderBook") : undefined;
+            const url = route
+                ? `${HOSTED_CATALOG_BASE_URL}${formatRoutePath(route, { venue: this.exchangeName })}`
+                : `${this.resolveBaseUrl()}/api/${this.exchangeName}/fetchOrderBook`;
+            const response = await this.fetchWithRetry(url, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
                 body: JSON.stringify({ args, credentials: this.getCredentials() }),
@@ -1105,7 +1110,11 @@ export abstract class Exchange {
         try {
             const args: any[] = [];
             args.push(outcomeIds.map(resolveOutcomeId));
-            const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/fetchOrderBooks`, {
+            const route = this.pmxtApiKey ? HOSTED_METHOD_ROUTES.get("fetchOrderBooks") : undefined;
+            const url = route
+                ? `${HOSTED_CATALOG_BASE_URL}${formatRoutePath(route, { venue: this.exchangeName })}`
+                : `${this.resolveBaseUrl()}/api/${this.exchangeName}/fetchOrderBooks`;
+            const response = await this.fetchWithRetry(url, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
                 body: JSON.stringify({ args, credentials: this.getCredentials() }),

--- a/sdks/typescript/pmxt/hosted-routing.ts
+++ b/sdks/typescript/pmxt/hosted-routing.ts
@@ -44,6 +44,8 @@ export const HOSTED_METHOD_ROUTES: ReadonlyMap<string, HostedRoute> = new Map([
     ["fetchMyTrades",     { method: "GET",  path: "/v0/user/{address}/trades",        base: "trading", requiresWalletAddress: true }],
     ["fetchBalance",      { method: "GET",  path: "/v0/user/{address}/balances",      base: "trading", requiresWalletAddress: true }],
     ["fetchPositions",    { method: "GET",  path: "/v0/user/{address}/positions",     base: "trading", requiresWalletAddress: true }],
+    ["fetchOrderBook",    { method: "POST", path: "/api/{venue}/fetchOrderBook",      base: "catalog" }],
+    ["fetchOrderBooks",   { method: "POST", path: "/api/{venue}/fetchOrderBooks",     base: "catalog" }],
     ["escrowApproveTx",   { method: "POST", path: "/v0/escrow/approve",               base: "trading" }],
     ["escrowDepositTx",   { method: "POST", path: "/v0/escrow/deposit",               base: "trading" }],
     ["escrowWithdrawTx",  { method: "POST", path: "/v0/escrow/withdraw",              base: "trading" }],

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -21,6 +21,8 @@ jest.mock("../pmxt/hosted-typed-data", () => ({
 
 import { Polymarket } from "../pmxt/client";
 import {
+  HOSTED_CATALOG_BASE_URL,
+  HOSTED_METHOD_ROUTES,
   HOSTED_TRADING_BASE_URL,
 } from "../pmxt/hosted-routing";
 import { NotSupported } from "../pmxt/errors";
@@ -85,6 +87,49 @@ afterEach(() => {
 // --------------------------------------------------------------------------
 
 describe("hosted read dispatch", () => {
+  it("route table includes hosted catalog order book reads", () => {
+    expect(HOSTED_METHOD_ROUTES.get("fetchOrderBook")).toMatchObject({
+      method: "POST",
+      path: "/api/{venue}/fetchOrderBook",
+      base: "catalog",
+    });
+    expect(HOSTED_METHOD_ROUTES.get("fetchOrderBooks")).toMatchObject({
+      method: "POST",
+      path: "/api/{venue}/fetchOrderBooks",
+      base: "catalog",
+    });
+  });
+
+  it("fetchOrderBook → hosted catalog /api/{venue}/fetchOrderBook", async () => {
+    const spy = installFetchSpy(() =>
+      jsonResponse({ success: true, data: { bids: [], asks: [] } }),
+    );
+    const api = makePolymarket();
+    await api.fetchOrderBook("outcome-1", 5, { outcome: "yes" } as any);
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toBe(`${HOSTED_CATALOG_BASE_URL}/api/polymarket/fetchOrderBook`);
+    expect(reqs[0].init?.method).toBe("POST");
+    const headers = reqs[0].init?.headers as Record<string, string> | undefined;
+    expect(headers?.Authorization).toBe(`Bearer ${PMXT_API_KEY}`);
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body.args).toEqual(["outcome-1", 5, { outcome: "yes" }]);
+  });
+
+  it("fetchOrderBooks → hosted catalog /api/{venue}/fetchOrderBooks", async () => {
+    const spy = installFetchSpy(() =>
+      jsonResponse({ success: true, data: { "outcome-1": { bids: [], asks: [] } } }),
+    );
+    const api = makePolymarket();
+    await api.fetchOrderBooks(["outcome-1"]);
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toBe(`${HOSTED_CATALOG_BASE_URL}/api/polymarket/fetchOrderBooks`);
+    expect(reqs[0].init?.method).toBe("POST");
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body.args).toEqual([["outcome-1"]]);
+  });
+
   it("fetchBalance → GET /v0/user/{addr}/balances", async () => {
     const spy = installFetchSpy(() =>
       jsonResponse({ balances: [{ currency: "USDC", amount: 12.5 }] }),

--- a/sdks/typescript/tests/hosted-routing.test.ts
+++ b/sdks/typescript/tests/hosted-routing.test.ts
@@ -1,0 +1,16 @@
+import { HOSTED_METHOD_ROUTES } from "../pmxt/hosted-routing";
+
+describe("hosted routing table", () => {
+  it("routes order book reads through the hosted catalog API", () => {
+    expect(HOSTED_METHOD_ROUTES.get("fetchOrderBook")).toMatchObject({
+      method: "POST",
+      path: "/api/{venue}/fetchOrderBook",
+      base: "catalog",
+    });
+    expect(HOSTED_METHOD_ROUTES.get("fetchOrderBooks")).toMatchObject({
+      method: "POST",
+      path: "/api/{venue}/fetchOrderBooks",
+      base: "catalog",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add TypeScript hosted route-table entries for `fetchOrderBook` and `fetchOrderBooks` to match Python hosted routing.
- Route hosted TypeScript order-book reads through the catalog hosted endpoint using the shared hosted routing table instead of constructing a fallback URL inline.
- Add regression coverage for the route table and hosted dispatch URLs/bodies.

Fixes #1011

## Test Plan
- `npm test -- --runTestsByPath tests/hosted-routing.test.ts --runInBand` (from `sdks/typescript`) ✅
- `npm test -- --runTestsByPath tests/hosted-dispatch.test.ts --runInBand` (from `sdks/typescript`) ⚠️ blocked locally before test execution because generated TypeScript client files are absent and `npm run generate --workspace=pmxtjs` requires `java`, which is not installed in this cron host.
