### PR TITLE
fix(python): drop generated router exchange stub

### DIFF
--- a/core/scripts/generate-python-exchanges.js
+++ b/core/scripts/generate-python-exchanges.js
@@ -105,7 +105,7 @@ function parseExchanges(content) {
     }
     if (currentName) exchanges.push(build(currentName, currentBlock));
 
-    return exchanges;
+    return exchanges.filter(ex => ex.name !== 'router');
 }
 
 function build(name, block) {

--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List
 
 from .client import Exchange
 from .constants import ENV, ENV_BASE_URL, ENV_API_KEY
-from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Polymarket_us, Hyperliquid, GeminiTitan, SuiBets, Suibets, Mock, Router
+from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Polymarket_us, Hyperliquid, GeminiTitan, SuiBets, Suibets, Mock
 from .router import Router
 from .feed_client import FeedClient
 from .server_manager import ServerManager
@@ -185,7 +185,6 @@ __all__ = [
     "SuiBets",
     "Suibets",
     "Mock",
-    "Router",
     "Exchange",
     "FeedClient",
     "ExchangeOptions",

--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -21,10 +21,6 @@ class Polymarket(Exchange):
         base_url: Optional[str] = None,
         auto_start_server: Optional[bool] = None,
         pmxt_api_key: Optional[str] = None,
-        # NOTE: Generated wrapper; update the generator template in
-        # core/scripts/generate-python-exchanges.js in a follow-up.
-        wallet_address: Optional[str] = None,
-        signer: Optional[object] = None,
     ) -> None:
         """
         Initialize Polymarket client.
@@ -39,8 +35,6 @@ class Polymarket(Exchange):
             base_url: Base URL of the PMXT sidecar server
             auto_start_server: Automatically start server if not running (default: True)
             pmxt_api_key: Hosted PMXT API key (optional; enables hosted mode)
-            wallet_address: Ethereum address for hosted reads/writes (optional)
-            signer: Optional callable for signing typed_data (optional)
         """
         super().__init__(
             exchange_name="polymarket",
@@ -51,8 +45,6 @@ class Polymarket(Exchange):
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,
-            wallet_address=wallet_address,
-            signer=signer,
         )
 
         self.api_secret = api_secret
@@ -296,10 +288,6 @@ class Opinion(Exchange):
         base_url: Optional[str] = None,
         auto_start_server: Optional[bool] = None,
         pmxt_api_key: Optional[str] = None,
-        # NOTE: Generated wrapper; update the generator template in
-        # core/scripts/generate-python-exchanges.js in a follow-up.
-        wallet_address: Optional[str] = None,
-        signer: Optional[object] = None,
     ) -> None:
         """
         Initialize Opinion client.
@@ -311,8 +299,6 @@ class Opinion(Exchange):
             base_url: Base URL of the PMXT sidecar server
             auto_start_server: Automatically start server if not running (default: True)
             pmxt_api_key: Hosted PMXT API key (optional; enables hosted mode)
-            wallet_address: Ethereum address for hosted reads/writes (optional)
-            signer: Optional callable for signing typed_data (optional)
         """
         super().__init__(
             exchange_name="opinion",
@@ -322,8 +308,6 @@ class Opinion(Exchange):
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,
-            wallet_address=wallet_address,
-            signer=signer,
         )
 
 
@@ -530,31 +514,6 @@ class Mock(Exchange):
         """
         super().__init__(
             exchange_name="mock",
-            base_url=base_url,
-            auto_start_server=auto_start_server,
-            pmxt_api_key=pmxt_api_key,
-        )
-
-
-class Router(Exchange):
-    """Router exchange client."""
-
-    def __init__(
-        self,
-        base_url: Optional[str] = None,
-        auto_start_server: Optional[bool] = None,
-        pmxt_api_key: Optional[str] = None,
-    ) -> None:
-        """
-        Initialize Router client.
-
-        Args:
-            base_url: Base URL of the PMXT sidecar server
-            auto_start_server: Automatically start server if not running (default: True)
-            pmxt_api_key: Hosted PMXT API key (optional; enables hosted mode)
-        """
-        super().__init__(
-            exchange_name="router",
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,


### PR DESCRIPTION
## Summary
- Exclude the special router entry from generated exchange wrappers.
- Regenerate Python exchange exports so direct imports no longer expose a bare `pmxt._exchanges.Router(Exchange)` stub; the real `pmxt.router.Router` remains exported from `pmxt`.

Fixes #976

## Test Plan
- `npm run generate:python-exchanges --workspace=pmxt-core`
- `grep -q "class Router(Exchange)" sdks/python/pmxt/_exchanges.py && exit 1 || true`
- `grep -q "from .router import Router" sdks/python/pmxt/__init__.py`
- `python3 -m py_compile sdks/python/pmxt/_exchanges.py sdks/python/pmxt/__init__.py`
- `git diff --check`