### PR TITLE
fix(python-sdk): serialize approve amount_wei as string

### DIFF
--- a/sdks/python/pmxt/escrow.py
+++ b/sdks/python/pmxt/escrow.py
@@ -43,7 +43,7 @@ def _approval_token(token: str) -> str:
     )
 
 
-def _amount_wei(value: int | None) -> int | None:
+def _amount_wei(value: int | None) -> str | None:
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, int):
@@ -53,7 +53,7 @@ def _amount_wei(value: int | None) -> int | None:
         )
     if value < 0:
         raise ValidationError("amount_wei must be non-negative", field="amount_wei")
-    return value
+    return str(value)
 
 
 def _usdc_amount(value: float | Decimal, *, field: str = "amount") -> float:

--- a/sdks/python/tests/test_escrow_amount_wei.py
+++ b/sdks/python/tests/test_escrow_amount_wei.py
@@ -1,0 +1,36 @@
+"""Tests for hosted escrow transaction body helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+
+def _load_escrow_module():
+    """Load pmxt.escrow without importing pmxt.__init__.
+
+    The generated pmxt_internal package is not checked in, and pmxt.__init__
+    imports the full client. These helper-level tests only need sibling pmxt
+    modules, so install a minimal package shell and load escrow directly.
+    """
+    package_root = pathlib.Path(__file__).resolve().parents[1] / "pmxt"
+    pkg = types.ModuleType("pmxt")
+    pkg.__path__ = [str(package_root)]
+    sys.modules.setdefault("pmxt", pkg)
+    spec = importlib.util.spec_from_file_location(
+        "pmxt.escrow",
+        package_root / "escrow.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pmxt.escrow"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_approval_amount_wei_serializes_as_string_for_json_wire_format():
+    escrow = _load_escrow_module()
+
+    assert escrow._amount_wei(2**96 - 1) == str(2**96 - 1)


### PR DESCRIPTION
## Summary
- Serialize Python `Escrow.approve_tx(..., amount_wei=...)` values as strings to match TypeScript `approveTx` wire format.
- Add a focused regression test for a large Wei approval amount.

Fixes #1025

## Test Plan
- `pytest sdks/python/tests/test_escrow_amount_wei.py::test_approval_amount_wei_serializes_as_string_for_json_wire_format -q`
- `pytest sdks/python/tests/test_escrow_amount_wei.py -q`

## Notes
- `sdks/python/tests/test_hosted_dispatch.py` cannot be collected directly in this checkout without generated `pmxt_internal`; the new helper-level test loads `pmxt.escrow` directly to avoid requiring generated SDK artifacts for this narrow regression.
