### PR TITLE
fix(sdk): expose order book metadata fields

### DIFF
--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -310,6 +310,9 @@ class OrderLevel:
     size: float
     """Number of contracts"""
 
+    order_count: Optional[float] = None
+    """Number of venue orders aggregated at this price level, when provided."""
+
 
 @dataclass
 class OrderBook:
@@ -326,6 +329,15 @@ class OrderBook:
 
     datetime: Optional[str] = None
     """ISO 8601 datetime string (CCXT-compatible)"""
+
+    is_neg_risk: Optional[bool] = None
+    """Whether the venue marks this snapshot as a negative-risk market."""
+
+    last_trade_price: Optional[float] = None
+    """Last traded price included with the book snapshot, when provided."""
+
+    source_metadata: Optional[Dict[str, Any]] = None
+    """Raw venue-specific fields preserved from the order book snapshot."""
 
 
 @dataclass

--- a/sdks/python/tests/test_converters.py
+++ b/sdks/python/tests/test_converters.py
@@ -608,6 +608,20 @@ class TestConvertOrderBook:
         book = _convert_order_book(raw)
         assert book.timestamp == 1700000000000
 
+    def test_order_book_extended_fields_mapped(self):
+        raw = {
+            "bids": [{"price": 0.68, "size": 150.0, "orderCount": 3}],
+            "asks": [],
+            "isNegRisk": True,
+            "lastTradePrice": 0.69,
+            "sourceMetadata": {"venue": "polymarket"},
+        }
+        book = _convert_order_book(raw)
+        assert book.bids[0].order_count == 3
+        assert book.is_neg_risk is True
+        assert book.last_trade_price == 0.69
+        assert book.source_metadata == {"venue": "polymarket"}
+
     def test_timestamp_none_when_absent(self):
         raw = {"bids": [], "asks": []}
         book = _convert_order_book(raw)

--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -149,6 +149,9 @@ export interface OrderLevel {
 
     /** Number of contracts */
     size: number;
+
+    /** Number of venue orders aggregated at this price level, when provided. */
+    orderCount?: number;
 }
 
 /**
@@ -166,6 +169,15 @@ export interface OrderBook {
 
     /** ISO 8601 datetime string of the snapshot (CCXT-compatible) */
     datetime?: string;
+
+    /** Whether the venue marks this snapshot as a negative-risk market. */
+    isNegRisk?: boolean;
+
+    /** Last traded price included with the book snapshot, when provided. */
+    lastTradePrice?: number;
+
+    /** Raw venue-specific fields preserved from the order book snapshot. */
+    sourceMetadata?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add missing `orderCount`/`order_count` support to SDK order-book levels.
- Add missing `isNegRisk`, `lastTradePrice`, and `sourceMetadata` fields to SDK order-book models.
- Add Python converter coverage to prove camelCase wire fields populate the snake_case dataclass fields.

Fixes #1038
Fixes #1039

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/models.py sdks/python/tests/test_converters.py` ✅
- `git diff --check` ✅
- `python3 -m pytest sdks/python/tests/test_converters.py -q` blocked locally: current checkout lacks generated `pmxt_internal` module (`ModuleNotFoundError: No module named 'pmxt_internal'`).
- `npm run build --workspace=pmxtjs` blocked locally: npm workspace install did not provide `tsc` in this cron worktree (`sh: 1: tsc: not found`), after repeated install attempts timed out/failed with npm ENOTEMPTY on transient node_modules renames.
