### PR TITLE
fix(ts-sdk): include wallet on escrow withdrawals

### DIFF
--- a/sdks/typescript/pmxt/escrow.ts
+++ b/sdks/typescript/pmxt/escrow.ts
@@ -63,14 +63,20 @@ export class Escrow {
         const route = HOSTED_METHOD_ROUTES.get("escrowWithdrawTx")!;
         const normalizedAmount =
             amount === undefined
-                ? null
+                ? undefined
                 : typeof amount === "bigint"
                   ? amount.toString()
                   : amount;
+        const address = resolveWalletAddress(this.client);
         return _tradingRequest(this.client, {
             method: route.method,
             path: route.path,
-            body: { action, amount: normalizedAmount },
+            body: {
+                action,
+                token: "usdc",
+                ...(normalizedAmount === undefined ? {} : { amount: normalizedAmount }),
+                user_address: address,
+            },
         });
     }
 

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -351,6 +351,45 @@ describe("hosted write dispatch", () => {
     expect("market_id" in body).toBe(false);
   });
 
+  it("escrow.withdrawTx request sends wallet and token fields", async () => {
+    const spy = installFetchSpy(() => jsonResponse({ tx: { to: "0x" + "1".repeat(40) } }));
+    const api = makePolymarket();
+    await api.escrow!.withdrawTx("request", 10);
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toContain("/v0/escrow/withdraw");
+    expect(reqs[0].init?.method).toBe("POST");
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body).toEqual({
+      action: "request",
+      token: "usdc",
+      amount: 10,
+      user_address: WALLET_ADDRESS,
+    });
+  });
+
+  it("escrow.withdrawTx claim omits amount while still identifying wallet and token", async () => {
+    const spy = installFetchSpy(() => jsonResponse({ tx: { to: "0x" + "1".repeat(40) } }));
+    const api = makePolymarket();
+    await api.escrow!.withdrawTx("claim");
+    const reqs = captured(spy);
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body).toEqual({
+      action: "claim",
+      token: "usdc",
+      user_address: WALLET_ADDRESS,
+    });
+  });
+
+  it("escrow.withdrawTx without wallet raises MissingWalletAddress before request", async () => {
+    const spy = installFetchSpy(() => jsonResponse({}));
+    const api = makePolymarket({ withWallet: false });
+    await expect(api.escrow!.withdrawTx("request", 10)).rejects.toBeInstanceOf(
+      MissingWalletAddress,
+    );
+    expect(captured(spy)).toHaveLength(0);
+  });
+
   it("cancelOrder → POST cancel/build then POST cancel", async () => {
     let call = 0;
     const spy = installFetchSpy(() => {


### PR DESCRIPTION
## Summary
- Align TypeScript `client.escrow.withdrawTx()` with Python `withdraw_tx()` by including `token: "usdc"` and the resolved `user_address` in the `/v0/escrow/withdraw` request body.
- Omit `amount` for non-request actions instead of sending `null`, matching the Python SDK wire shape.
- Add hosted dispatch regression coverage for request/claim bodies and missing wallet validation.

Fixes #1050

## Test Plan
- `python3` static regression assertions over the touched TypeScript source/test files passed.
- `jest tests/hosted-dispatch.test.ts` and `tsc --noEmit` could not complete in this cron environment: Jest/Node startup hung until the scheduler timeout with no test output, including `--showConfig`.
