### PR TITLE
fix(ts-sdk): export flat env constants

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -31,7 +31,7 @@ export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
 export { Router } from "./pmxt/router.js";
 export { ServerManager } from "./pmxt/server-manager.js";
-export { HOSTED_URL, LOCAL_URL, ENV, resolvePmxtBaseUrl } from "./pmxt/constants.js";
+export { HOSTED_URL, LOCAL_URL, ENV, ENV_BASE_URL, ENV_API_KEY, resolvePmxtBaseUrl } from "./pmxt/constants.js";
 export { MarketList } from "./pmxt/models.js";
 export type { UnifiedSeries } from "./pmxt/models.js";
 export type * from "./pmxt/models.js";

--- a/sdks/typescript/pmxt/constants.ts
+++ b/sdks/typescript/pmxt/constants.ts
@@ -33,6 +33,12 @@ export const ENV = {
     API_KEY: "PMXT_API_KEY",
 } as const;
 
+/** Environment variable name for overriding the pmxt base URL. */
+export const ENV_BASE_URL = ENV.BASE_URL;
+
+/** Environment variable name for supplying a hosted pmxt API key. */
+export const ENV_API_KEY = ENV.API_KEY;
+
 /**
  * Resolve the effective base URL for an SDK client, following the
  * documented precedence rules:

--- a/sdks/typescript/tests/public-exports.test.ts
+++ b/sdks/typescript/tests/public-exports.test.ts
@@ -16,4 +16,9 @@ describe('public exports', () => {
     const client = new pmxt.FeedClient('chainlink');
     expect(client).toBeInstanceOf(DirectFeedClient);
   });
+
+  it('exports flat environment variable constants alongside ENV', () => {
+    expect(pmxt.ENV_BASE_URL).toBe(pmxt.ENV.BASE_URL);
+    expect(pmxt.ENV_API_KEY).toBe(pmxt.ENV.API_KEY);
+  });
 });


### PR DESCRIPTION
## Summary
- Add TypeScript top-level `ENV_BASE_URL` and `ENV_API_KEY` exports as flat aliases of `ENV.BASE_URL` and `ENV.API_KEY`.
- Cover the aliases in the public exports test.

Fixes #1029

## Test Plan
- `git diff --check`
- Static export assertions for `sdks/typescript/pmxt/constants.ts`, `sdks/typescript/index.ts`, and `sdks/typescript/tests/public-exports.test.ts`

Note: attempted `npm test -- --runTestsByPath tests/public-exports.test.ts`, but this worktree had no installed Jest; `npm install`/`npm ci` were blocked by cron environment timeouts/OOM before dependencies completed.
