### PR TITLE
Forward TypeScript order optional params

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -2104,6 +2104,15 @@ export abstract class Exchange {
             if (params.fee !== undefined) {
                 paramsDict.fee = params.fee;
             }
+            if (params.tickSize !== undefined) {
+                paramsDict.tickSize = params.tickSize;
+            }
+            if (params.negRisk !== undefined) {
+                paramsDict.negRisk = params.negRisk;
+            }
+            if (params.onBehalfOf !== undefined) {
+                paramsDict.onBehalfOf = params.onBehalfOf;
+            }
 
             const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/buildOrder`, {
                 method: 'POST',
@@ -2405,6 +2414,15 @@ export abstract class Exchange {
             }
             if (params.fee !== undefined) {
                 paramsDict.fee = params.fee;
+            }
+            if (params.tickSize !== undefined) {
+                paramsDict.tickSize = params.tickSize;
+            }
+            if (params.negRisk !== undefined) {
+                paramsDict.negRisk = params.negRisk;
+            }
+            if (params.onBehalfOf !== undefined) {
+                paramsDict.onBehalfOf = params.onBehalfOf;
             }
 
             const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/createOrder`, {

--- a/sdks/typescript/tests/sidecar-order-param-forwarding.test.ts
+++ b/sdks/typescript/tests/sidecar-order-param-forwarding.test.ts
@@ -1,0 +1,104 @@
+import { Polymarket } from "../pmxt/client";
+import { LOCAL_URL } from "../pmxt/constants";
+
+interface CapturedFetch {
+  url: string;
+  init?: RequestInit;
+}
+
+function installFetchSpy(handler: (req: CapturedFetch) => Response): jest.SpyInstance {
+  const captured: CapturedFetch[] = [];
+  const spy = jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as URL | Request).toString();
+    const rec: CapturedFetch = { url, init };
+    captured.push(rec);
+    return handler(rec);
+  });
+  (spy as unknown as { captured: CapturedFetch[] }).captured = captured;
+  return spy;
+}
+
+function captured(spy: jest.SpyInstance): CapturedFetch[] {
+  return (spy as unknown as { captured: CapturedFetch[] }).captured;
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makePolymarket(): Polymarket {
+  return new Polymarket({ autoStartServer: false, baseUrl: LOCAL_URL });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("sidecar order param forwarding", () => {
+  it("buildOrder forwards tickSize, negRisk, and onBehalfOf", async () => {
+    const spy = installFetchSpy(() =>
+      jsonResponse({
+        success: true,
+        data: { id: "built-1" },
+      }),
+    );
+    const api = makePolymarket();
+
+    await api.buildOrder({
+      marketId: "market-1",
+      outcomeId: "outcome-1",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.45,
+      tickSize: 0.01,
+      negRisk: false,
+      onBehalfOf: 123,
+    });
+
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toBe(`${LOCAL_URL}/api/polymarket/buildOrder`);
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body.args[0]).toMatchObject({
+      tickSize: 0.01,
+      negRisk: false,
+      onBehalfOf: 123,
+    });
+  });
+
+  it("createOrder forwards tickSize, negRisk, and onBehalfOf", async () => {
+    const spy = installFetchSpy(() =>
+      jsonResponse({
+        success: true,
+        data: { id: "order-1", status: "open" },
+      }),
+    );
+    const api = makePolymarket();
+
+    await api.createOrder({
+      marketId: "market-1",
+      outcomeId: "outcome-1",
+      side: "buy",
+      type: "limit",
+      amount: 10,
+      price: 0.45,
+      tickSize: 0.01,
+      negRisk: false,
+      onBehalfOf: 0,
+    });
+
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toBe(`${LOCAL_URL}/api/polymarket/createOrder`);
+    const body = JSON.parse((reqs[0].init?.body as string) ?? "{}");
+    expect(body.args[0]).toMatchObject({
+      tickSize: 0.01,
+      negRisk: false,
+      onBehalfOf: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Forward `tickSize`, `negRisk`, and `onBehalfOf` in TypeScript SDK local sidecar `buildOrder()` requests.
- Forward the same optional fields in local sidecar `createOrder()` requests.
- Add focused Jest coverage proving both request bodies retain those fields. The test fixes the base URL to `LOCAL_URL` and covers `negRisk: false` plus `onBehalfOf: 0` so falsy values are not dropped.

Fixes #1031

## Validation
- `git diff --check` -> passed.
- `npx jest --runTestsByPath tests/sidecar-order-param-forwarding.test.ts --globals '{"ts-jest":{"diagnostics":false}}'` -> 2 passed.
- `npm test -- --runTestsByPath tests/sidecar-order-param-forwarding.test.ts --runInBand` is blocked before execution by an existing `upstream/main` TypeScript diagnostic: missing `_hostedSubmitOrder` on `Exchange`.
- Existing `tests/hosted-dispatch.test.ts` is blocked by the same diagnostic, confirming this is not introduced by this test.
- Java 17 `npm run build --workspace=pmxtjs` was attempted and is blocked by existing TypeScript errors: missing `_hostedSubmitOrder` and `limitless_buy` schema key.

## Review
- Independent adversarial review found one test-stability issue; addressed by forcing `baseUrl: LOCAL_URL` and adding `onBehalfOf: 0` coverage.
- Follow-up adversarial review had no P0/P2 findings; the remaining P1 is the unrelated upstream TypeScript diagnostic noted above.
