### PR TITLE
fix(core): register suibets and polymarket_us defaults

### DIFF
--- a/core/src/server/app.ts
+++ b/core/src/server/app.ts
@@ -254,6 +254,8 @@ const defaultExchanges: Record<string, any> = {
   opinion: null,
   metaculus: null,
   smarkets: null,
+  polymarket_us: null,
+  suibets: null,
   mock: null,
 };
 

--- a/core/test/pipeline/default-exchanges.test.ts
+++ b/core/test/pipeline/default-exchanges.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+
+function readRepoFile(relativePath: string): string {
+    return fs.readFileSync(path.join(__dirname, '..', '..', relativePath), 'utf8');
+}
+
+describe('sidecar default exchange registry', () => {
+    test('includes every public exchange that the factory can create without per-request credentials', () => {
+        const appSource = readRepoFile('src/server/app.ts');
+        const factorySource = readRepoFile('src/server/exchange-factory.ts');
+
+        for (const exchangeName of ['suibets', 'polymarket_us']) {
+            expect(factorySource).toContain(`case "${exchangeName}"`);
+            expect(appSource).toMatch(new RegExp(`${exchangeName}:\\s*null`));
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Register `suibets` and `polymarket_us` in the sidecar default exchange singleton map.
- Add a regression test so public exchanges implemented by `createExchange` stay present in `defaultExchanges` for credential-free read requests.

Fixes #1062

## Test Plan
- `npm --workspace=pmxt-core test -- --runTestsByPath test/pipeline/default-exchanges.test.ts --runInBand`
- `npm --workspace=pmxt-core test -- --runTestsByPath test/pipeline/error-propagation.test.ts --runInBand`
- `npm run build --workspace=pmxt-core`
