### PR TITLE
fix(ts-sdk): export Limitless venue escrow constants

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -31,7 +31,15 @@ export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
 export { Router } from "./pmxt/router.js";
 export { ServerManager } from "./pmxt/server-manager.js";
-export { HOSTED_URL, LOCAL_URL, ENV, resolvePmxtBaseUrl } from "./pmxt/constants.js";
+export {
+    HOSTED_URL,
+    LOCAL_URL,
+    ENV,
+    resolvePmxtBaseUrl,
+    PREFUNDED_ESCROW_ADDRESSES,
+    VENUE_ESCROW_ADDRESSES,
+    LIMITLESS_VENUE_ESCROW_ADDRESSES,
+} from "./pmxt/constants.js";
 export { MarketList } from "./pmxt/models.js";
 export type { UnifiedSeries } from "./pmxt/models.js";
 export type * from "./pmxt/models.js";

--- a/sdks/typescript/pmxt/constants.ts
+++ b/sdks/typescript/pmxt/constants.ts
@@ -80,3 +80,10 @@ export const PREFUNDED_ESCROW_ADDRESSES: ReadonlySet<string> = new Set([
  * as venue-owned escrows. Currently empty; populated as venues onboard.
  */
 export const VENUE_ESCROW_ADDRESSES: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Limitless VenueEscrow contract addresses on Base (chain 8453).
+ */
+export const LIMITLESS_VENUE_ESCROW_ADDRESSES: ReadonlySet<string> = new Set([
+    "0x34c42d01aad6ded00f1a6830d90b0e9204db7855",
+]);

--- a/sdks/typescript/pmxt/hosted-typed-data.ts
+++ b/sdks/typescript/pmxt/hosted-typed-data.ts
@@ -123,7 +123,7 @@ const VENUE_DOMAIN: DomainSchema = {
     chainId: 56,
     allowlistKey: "venue",
 };
-const LIMITLESS_VENUE_DOMAIN = {
+const LIMITLESS_VENUE_DOMAIN: DomainSchema = {
     name: "VenueEscrow",
     version: "1",
     chainId: 8453,

--- a/sdks/typescript/pmxt/hosted-typed-data.ts
+++ b/sdks/typescript/pmxt/hosted-typed-data.ts
@@ -133,6 +133,9 @@ const LIMITLESS_VENUE_DOMAIN = {
 export type HostedRoute =
     | "polymarket_buy"
     | "polymarket_sell"
+    | "limitless_buy"
+    | "limitless_sell_polygon"
+    | "limitless_sell_base_pull"
     | "opinion_buy"
     | "opinion_sell_polygon"
     | "opinion_sell_bsc_pull"
@@ -725,7 +728,9 @@ function allowedAddresses(
     const raw =
         key === "prefunded"
             ? (constants as any).PREFUNDED_ESCROW_ADDRESSES
-            : (constants as any).VENUE_ESCROW_ADDRESSES;
+            : chainId === 8453
+              ? (constants as any).LIMITLESS_VENUE_ESCROW_ADDRESSES
+              : (constants as any).VENUE_ESCROW_ADDRESSES;
     const list: unknown[] = [];
     if (raw == null) {
         // empty


### PR DESCRIPTION
## Summary
- Export `LIMITLESS_VENUE_ESCROW_ADDRESSES` from the TypeScript SDK constants surface.
- Route Base/8453 VenueEscrow typed-data allowlist checks through the Limitless-specific address set.
- Include existing Limitless hosted typed-data route keys in the `HostedRoute` union.

Fixes #1060

## Test Plan
- `npm test --workspace=pmxtjs -- --runTestsByPath sdks/typescript/tests/hosted-dispatch.test.ts sdks/typescript/tests/hosted-error-mapping.test.ts` *(blocked: workspace dev dependencies are not installed in this cron checkout; `jest: not found`)*
- `npm install` / `npm ci --workspace=pmxtjs` *(blocked: dependency install timed out after 10 minutes in the cron environment)*
