### PR TITLE
fix(python-sdk): warn on silent sidecar cleanup failures

### DIFF
--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -12,6 +12,7 @@ import sys
 import time
 import urllib.error
 import uuid
+import warnings
 from abc import ABC
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
@@ -210,8 +211,12 @@ def _convert_market(raw: Dict[str, Any]) -> UnifiedMarket:
         if isinstance(res_date_raw, str):
             try:
                 res_date = datetime.fromisoformat(res_date_raw.replace("Z", "+00:00"))
-            except ValueError:
-                pass
+            except ValueError as exc:
+                warnings.warn(
+                    f"Ignoring malformed resolutionDate {res_date_raw!r}: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
         elif isinstance(res_date_raw, datetime):
             res_date = res_date_raw
 
@@ -509,8 +514,12 @@ class Exchange(ABC):
                 if attempt == 0 and not self.pmxt_api_key:
                     try:
                         self._server_manager.ensure_server_running()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        warnings.warn(
+                            f"Failed to restart PMXT sidecar after connection error: {exc}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
                 time.sleep(delays[attempt])
             except ApiException:
                 raise  # HTTP errors are not retryable here

--- a/sdks/python/pmxt/server_manager.py
+++ b/sdks/python/pmxt/server_manager.py
@@ -19,6 +19,7 @@ import time
 import subprocess
 import shutil
 import threading
+import warnings
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 import urllib.request
@@ -312,8 +313,12 @@ class ServerManager:
                     import signal
                     os.kill(pid, signal.SIGTERM)
                 time.sleep(0.5)
-            except (OSError, subprocess.TimeoutExpired):
-                pass
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                warnings.warn(
+                    f"Failed to terminate PMXT sidecar process {pid}: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
             # Verify the process is actually dead; escalate to SIGKILL if not
             if os.name != 'nt':
@@ -324,8 +329,12 @@ class ServerManager:
                     try:
                         os.kill(pid, signal.SIGKILL)
                         time.sleep(0.2)
-                    except OSError:
-                        pass
+                    except OSError as exc:
+                        warnings.warn(
+                            f"Failed to force-kill PMXT sidecar process {pid}: {exc}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
                 except (OSError, ProcessLookupError):
                     pass  # Process is dead — good
         self._remove_stale_lock()
@@ -394,8 +403,12 @@ class ServerManager:
         """Remove stale lock file."""
         try:
             self.lock_path.unlink()
-        except OSError:
-            pass
+        except OSError as exc:
+            warnings.warn(
+                f"Failed to remove stale PMXT sidecar lock {self.lock_path}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
     
     def _start_server_via_launcher(self) -> None:
         """


### PR DESCRIPTION
## Summary
- Replace four silent Python SDK exception handlers with `RuntimeWarning` diagnostics while preserving existing fallback behavior.
- Covers malformed resolution-date conversion, sidecar restart retry failure, SIGTERM/SIGKILL cleanup failure, and stale lock removal failure.

Fixes #1107
Fixes #1108
Fixes #1109
Fixes #1110

## Test Plan
- `python3 -m compileall -q sdks/python/pmxt/client.py sdks/python/pmxt/server_manager.py`
- `git diff --check`
- Attempted: `uv run --no-project --with pytest --with pytest-asyncio python -m pytest tests/test_client_startup.py tests/test_converters.py -q` (blocked because this checkout does not include/generated `pmxt_internal`, so tests fail during import before exercising the changed code)
