### PR TITLE
fix(ts-sdk): map hosted order provenance fields

### DIFF
--- a/sdks/typescript/pmxt/hosted-mappers.ts
+++ b/sdks/typescript/pmxt/hosted-mappers.ts
@@ -73,6 +73,21 @@ export function orderFromV0(payload: Record<string, unknown>): Order {
     const fee = floatOrUndefined(payload["fee"]);
     if (fee !== undefined) order.fee = fee;
 
+    const filledShares = floatOrUndefined(payload["filled_shares"] ?? payload["filledShares"]);
+    if (filledShares !== undefined) order.filledShares = filledShares;
+
+    const feeRateBps = floatOrUndefined(payload["fee_rate_bps"] ?? payload["feeRateBps"]);
+    if (feeRateBps !== undefined) order.feeRateBps = feeRateBps;
+
+    const txHash = strOrUndefined(payload["tx_hash"] ?? payload["txHash"]);
+    if (txHash !== undefined) order.txHash = txHash;
+
+    const chain = strOrUndefined(payload["chain"]);
+    if (chain !== undefined) order.chain = chain;
+
+    const blockNumber = floatOrUndefined(payload["block_number"] ?? payload["blockNumber"]);
+    if (blockNumber !== undefined) order.blockNumber = blockNumber;
+
     return order;
 }
 

--- a/sdks/typescript/tests/hosted-mappers.test.ts
+++ b/sdks/typescript/tests/hosted-mappers.test.ts
@@ -1,0 +1,31 @@
+import { orderFromV0 } from "../pmxt/hosted-mappers";
+
+describe("hosted order mappers", () => {
+  it("maps hosted v0 order provenance and fill metadata", () => {
+    const order = orderFromV0({
+      id: "ord_123",
+      market_id: "market_1",
+      outcome_id: "outcome_yes",
+      side: "buy",
+      type: "limit",
+      amount: "10",
+      status: "filled",
+      filled: "9.5",
+      filled_shares: "19",
+      remaining: "0.5",
+      fee: "0.12",
+      fee_rate_bps: "100",
+      price: "0.5",
+      timestamp: "2026-06-17T06:00:00Z",
+      tx_hash: "0xabc123",
+      chain: "polygon",
+      block_number: "12345678",
+    });
+
+    expect(order.filledShares).toBe(19);
+    expect(order.feeRateBps).toBe(100);
+    expect(order.txHash).toBe("0xabc123");
+    expect(order.chain).toBe("polygon");
+    expect(order.blockNumber).toBe(12345678);
+  });
+});


### PR DESCRIPTION
## Summary
- Map hosted v0 order provenance and fill metadata into the TypeScript `Order` object.
- Covers `filled_shares`, `fee_rate_bps`, `tx_hash`, `chain`, and `block_number`, with camelCase fallbacks for already-normalized payloads.
- Adds a focused regression test for the hosted order mapper.

Fixes #1122

## Test Plan
- `npm test --workspace=pmxtjs -- --runTestsByPath tests/hosted-mappers.test.ts --runInBand`
- `git diff --check`

Blocked/local environment note:
- `npm run build --workspace=pmxtjs` currently fails before this change is typechecked because this focused checkout does not include generated TypeScript artifacts at `sdks/typescript/generated/src/index.js`.
