### PR TITLE
fix(python-sdk): add wallet signer exchange options

### DIFF
--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -648,6 +648,8 @@ class ExchangeOptions(TypedDict, total=False):
     api_token: str
     proxy_address: str
     signature_type: Union[str, int]
+    wallet_address: str
+    signer: Any
 
 
 class PolymarketOptions(ExchangeOptions, total=False):


### PR DESCRIPTION
## Summary
- Add `wallet_address` and `signer` to the Python SDK `ExchangeOptions` TypedDict.
- Aligns the Python public option type with the TypeScript `ExchangeOptions` fields for hosted wallet/signer flows.

Fixes #1132

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/models.py`
- `python3 - <<'PY' ...` import-by-path smoke check asserting `ExchangeOptions` includes `wallet_address` and `signer`

Note: `python3 -m pytest sdks/python/tests/test_public_exports.py` could not run in this cron environment because `pytest` is not installed.
