### PR TITLE
fix(ts-sdk): register Limitless cancel typed-data routes

### DIFF
--- a/sdks/typescript/pmxt/hosted-typed-data.ts
+++ b/sdks/typescript/pmxt/hosted-typed-data.ts
@@ -423,7 +423,10 @@ export function validateEconomics(
     } else if (
         route === "opinion_buy" ||
         route === "opinion_sell_polygon" ||
-        route === "opinion_sell_bsc_pull"
+        route === "opinion_sell_bsc_pull" ||
+        route === "limitless_buy" ||
+        route === "limitless_sell_polygon" ||
+        route === "limitless_sell_base_pull"
     ) {
         validateOpinionMarketId(message, buildResponse);
     }

--- a/sdks/typescript/pmxt/hosted-typed-data.ts
+++ b/sdks/typescript/pmxt/hosted-typed-data.ts
@@ -140,6 +140,8 @@ export type HostedRoute =
     | "opinion_sell_polygon"
     | "opinion_sell_bsc_pull"
     | "cancel_polymarket"
+    | "cancel_limitless_polygon"
+    | "cancel_limitless_base_pull"
     | "cancel_opinion_polygon"
     | "cancel_opinion_bsc_pull";
 
@@ -205,6 +207,20 @@ const SCHEMAS: Readonly<Record<HostedRoute, TypedDataSchema>> = {
         domain: PREFUNDED_DOMAIN,
         fields: CANCEL_ORDER_FIELDS,
         messageKeys: messageKeysFromFields(CANCEL_ORDER_FIELDS),
+        walletField: "user",
+    },
+    cancel_limitless_polygon: {
+        primaryType: "CancelOrder",
+        domain: PREFUNDED_DOMAIN,
+        fields: CANCEL_ORDER_FIELDS,
+        messageKeys: messageKeysFromFields(CANCEL_ORDER_FIELDS),
+        walletField: "user",
+    },
+    cancel_limitless_base_pull: {
+        primaryType: "CancelPull",
+        domain: LIMITLESS_VENUE_DOMAIN,
+        fields: CANCEL_PULL_FIELDS,
+        messageKeys: messageKeysFromFields(CANCEL_PULL_FIELDS),
         walletField: "user",
     },
     cancel_opinion_polygon: {

--- a/sdks/typescript/tests/hosted-typed-data-routes.test.ts
+++ b/sdks/typescript/tests/hosted-typed-data-routes.test.ts
@@ -1,10 +1,27 @@
 import { validateEconomics } from "../pmxt/hosted-typed-data";
 
+const LIMITLESS_ORDER_ROUTES = [
+  "limitless_buy",
+  "limitless_sell_polygon",
+  "limitless_sell_base_pull",
+];
+
 describe("hosted typed-data route registry", () => {
   it.each([
     "cancel_limitless_polygon",
     "cancel_limitless_base_pull",
   ])("recognizes %s as a cancel route", (route) => {
     expect(() => validateEconomics({ message: {} } as any, route, {}, {})).not.toThrow();
+  });
+
+  it.each(LIMITLESS_ORDER_ROUTES)("validates tokenId economics for %s", (route) => {
+    expect(() =>
+      validateEconomics(
+        { message: { tokenId: "actual-token" } } as any,
+        route,
+        {},
+        { resolved: { token_id: "expected-token" } },
+      ),
+    ).toThrow(/tokenId expected expected-token got actual-token/);
   });
 });

--- a/sdks/typescript/tests/hosted-typed-data-routes.test.ts
+++ b/sdks/typescript/tests/hosted-typed-data-routes.test.ts
@@ -1,0 +1,10 @@
+import { validateEconomics } from "../pmxt/hosted-typed-data";
+
+describe("hosted typed-data route registry", () => {
+  it.each([
+    "cancel_limitless_polygon",
+    "cancel_limitless_base_pull",
+  ])("recognizes %s as a cancel route", (route) => {
+    expect(() => validateEconomics({ message: {} } as any, route, {}, {})).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Registers the TypeScript SDK Limitless hosted cancel typed-data routes in `HostedRoute` and `SCHEMAS`.
- Extends TypeScript economic validation so Limitless buy/sell typed-data routes reject mismatched `tokenId`, matching the Python guard.
- Adds focused regression tests for the Limitless cancel route registry and Limitless tokenId economics.

Fixes #1144
Fixes #1143

## Test Plan
- `npm test -- --runTestsByPath tests/hosted-typed-data-routes.test.ts`
- `git diff --check`

## Notes
- `npm test -- --runTestsByPath tests/hosted-dispatch.test.ts` is blocked in this focused worktree because `sdks/typescript/generated/src/index.js` is absent; no generated drift was committed for this focused hosted typed-data validation fix.
