### PR TITLE
fix(ts-sdk): forward router match browse options

### DIFF
--- a/sdks/typescript/pmxt/router.ts
+++ b/sdks/typescript/pmxt/router.ts
@@ -241,6 +241,8 @@ export class Router extends Exchange {
         minConfidence?: number;
         limit?: number;
         includePrices?: boolean;
+        minDifference?: number;
+        sort?: 'confidence' | 'volume' | 'priceDifference';
     }): Promise<MatchResult[]>;
     async fetchMarketMatches(marketOrParams: UnifiedMarket | {
         market?: UnifiedMarket;
@@ -253,6 +255,8 @@ export class Router extends Exchange {
         minConfidence?: number;
         limit?: number;
         includePrices?: boolean;
+        minDifference?: number;
+        sort?: 'confidence' | 'volume' | 'priceDifference';
     } = {}): Promise<MatchResult[]> {
         const params = 'title' in marketOrParams ? { market: marketOrParams as UnifiedMarket } : marketOrParams;
         await this.initPromise;
@@ -267,6 +271,8 @@ export class Router extends Exchange {
         if (params.minConfidence !== undefined) query.minConfidence = params.minConfidence;
         if (params.limit !== undefined) query.limit = params.limit;
         if (params.includePrices) query.includePrices = true;
+        if (params.minDifference !== undefined) query.minDifference = params.minDifference;
+        if (params.sort) query.sort = params.sort;
 
         try {
             const json = await this.sidecarReadRequest('fetchMarketMatches', query, [query]);


### PR DESCRIPTION
## Summary
- Add the missing TypeScript SDK `Router.fetchMarketMatches` option fields for `minDifference` and `sort`.
- Forward both fields through to the sidecar query so browse-mode filtering/sorting reaches core.

Closes #1149

## Test Plan
- `node - <<'NODE' ... typescript.transpileModule(sdks/typescript/pmxt/router.ts) ... NODE` — router.ts transpile diagnostics clean
- `git diff --check`
- `npm run build --workspace=pmxtjs` attempted after `npm install`; blocked by missing generated `sdks/typescript/generated/src/index.js` in this checkout
- `npm run generate:sdk:typescript --workspace=pmxt-core` attempted to restore generated SDK; blocked by environment missing `java`
