### PR TITLE
fix(hyperliquid): default fetchOHLCV params to {}

### DIFF
--- a/core/src/exchanges/hyperliquid/index.ts
+++ b/core/src/exchanges/hyperliquid/index.ts
@@ -145,7 +145,7 @@ export class HyperliquidExchange extends PredictionMarketExchange {
         return this.normalizer.normalizeOrderBook(raw, outcomeId);
     }
 
-    async fetchOHLCV(outcomeId: string, params: OHLCVParams): Promise<PriceCandle[]> {
+    async fetchOHLCV(outcomeId: string, params: OHLCVParams = {}): Promise<PriceCandle[]> {
         const raw = await this.fetcher.fetchRawOHLCV(outcomeId, params);
         return this.normalizer.normalizeOHLCV(raw, params);
     }


### PR DESCRIPTION
## Summary
- HL `fetchOHLCV(outcomeId, params)` had `params` typed as required. Server's flat-body dispatch (`app.ts`) merges body fields into a single object and passes it as `args[0]`, leaving `args[1]` undefined.
- Result: any MCP/HTTP call to `fetchOHLCV` for Hyperliquid crashes with `Cannot read properties of undefined (reading 'start')`.
- Other HL read methods (`fetchOrderBook`, `fetchTrades`) already make `params` optional and work fine.

## Repro
```
mcp pmxt.fetchOHLCV {exchange: 'hyperliquid', outcomeId: 'hl-outcome-172', resolution: '1h'}
→ PMXT API error: Cannot read properties of undefined (reading 'start')
```

## Test plan
- [ ] After deploy, re-run the MCP call above — expect candle array (or empty, not crash)
- [ ] Re-run with explicit `start`/`end` ISO strings — still works

## Known not fixed in this PR
- `fetchMarkets` / `fetchEvents` return `[]` for `exchange=hyperliquid` despite `loadMarkets` returning ~6000 markets. Root cause not yet identified from code reading; needs local repro against `npm run dev`.
- `outcomeId` parameter on HL read methods actually expects a marketId (`hl-outcome-{n}`), not the encoded outcome token id from `loadMarkets[].outcomes[].outcomeId`. Either the param naming or the handler is wrong — separate issue.