### PR TITLE
fix(sdks): use outcomeId in GET query for fetchOHLCV/fetchTrades

### DIFF
--- a/core/src/exchanges/hyperliquid/index.ts
+++ b/core/src/exchanges/hyperliquid/index.ts
@@ -145,7 +145,7 @@ export class HyperliquidExchange extends PredictionMarketExchange {
         return this.normalizer.normalizeOrderBook(raw, outcomeId);
     }
 
-    async fetchOHLCV(outcomeId: string, params: OHLCVParams = {}): Promise<PriceCandle[]> {
+    async fetchOHLCV(outcomeId: string, params: OHLCVParams = { resolution: '1h' }): Promise<PriceCandle[]> {
         const raw = await this.fetcher.fetchRawOHLCV(outcomeId, params);
         return this.normalizer.normalizeOHLCV(raw, params);
     }

--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -2235,7 +2235,7 @@ class Exchange(ABC):
                     params_dict[key] = value
 
             args = [outcome_id, params_dict]
-            query = {"id": outcome_id, **params_dict}
+            query = {"outcomeId": outcome_id, **params_dict}
             data = self._handle_response(
                 self._sidecar_read_request("fetchOHLCV", query, args)
             )
@@ -2295,7 +2295,7 @@ class Exchange(ABC):
                     params_dict[key] = value
 
             args = [outcome_id, params_dict]
-            query = {"id": outcome_id, **params_dict}
+            query = {"outcomeId": outcome_id, **params_dict}
             data = self._handle_response(
                 self._sidecar_read_request("fetchTrades", query, args)
             )

--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -1750,7 +1750,7 @@ export abstract class Exchange {
             }
 
             const args = [resolvedOutcomeId, paramsDict];
-            const query = { id: resolvedOutcomeId, ...paramsDict };
+            const query = { outcomeId: resolvedOutcomeId, ...paramsDict };
             const json = await this.sidecarReadRequest('fetchOHLCV', query, args);
             const data = this.handleResponse(json);
             return data.map(convertCandle);
@@ -1791,7 +1791,7 @@ export abstract class Exchange {
             }
 
             const args = [resolvedOutcomeId, paramsDict];
-            const query = { id: resolvedOutcomeId, ...paramsDict };
+            const query = { outcomeId: resolvedOutcomeId, ...paramsDict };
             const json = await this.sidecarReadRequest('fetchTrades', query, args);
             const data = this.handleResponse(json);
             return data.map(convertTrade);


### PR DESCRIPTION
## Summary
- Both Python and TS SDKs sent `?id=...` for GET reads, but the server's `method-verbs.json` spec for `fetchOHLCV` and `fetchTrades` declares the first positional arg as `outcomeId`. The GET dispatcher (`queryToArgs` in `core/src/server/app.ts`) peels primitive args by spec name, then bundles every remaining query key into the object arg. Result: `outcomeId` arrived `undefined`, and the raw key `id` ended up inside `params`. Downstream `fromMarketId(undefined)` crashed with `Cannot read properties of undefined (reading 'match')`.
- The POST path was unaffected (it sends positional `args: [outcomeId, params]` directly), which is why `fetchOrderBook` etc. never tripped.
- Also: default HL `fetchOHLCV` `params` to `{ resolution: '1h' }` so the typecheck from #1161 passes (`resolution` is required on `OHLCVParams`).

## Verified locally
Started `npm run server --workspace=pmxt-core` on port 3847, then ran both SDKs:

Python SDK:
```
fetch_markets: 2 (first: Fallback)
fetch_events: 2 (first: 2026 World Cup Champion)
fetch_order_book: bids=9 asks=12
fetch_ohlcv: 25 candles
fetch_trades: 10
```

TypeScript SDK:
```
fetchMarkets: 2 (first: Fallback)
fetchEvents: 2 (first: 2026 World Cup Champion)
fetchOrderBook: bids=9 asks=12
fetchOHLCV: 24 candles
fetchTrades: 10
```

All for `exchange='hyperliquid'`.

## Test plan
- [ ] CI on main passes (build was already broken by #1161 due to required `resolution`; this PR fixes that too)
- [ ] After deploy, hosted MCP `fetchOHLCV`/`fetchTrades` calls succeed with named params for any venue, not just HL

## Note on hosted MCP
The original failures I saw via the hosted MCP (`fetchMarkets`/`fetchEvents` returning `[]` for HL) **do not reproduce locally** against current `main`. Likely hosted-server version drift. Not in scope for this PR.