### PR TITLE
fix(core): register Rain, Gemini Titan, and Hyperliquid defaults

### DIFF
--- a/core/src/server/app.ts
+++ b/core/src/server/app.ts
@@ -243,19 +243,26 @@ function normalizeDispatchArgs(methodName: string, args: unknown[], exchange?: s
 }
 
 // Singleton instances for local usage (when no credentials provided)
-const defaultExchanges: Record<string, any> = {
-  polymarket: null,
-  limitless: null,
-  kalshi: null,
-  "kalshi-demo": null,
-  probable: null,
-  baozi: null,
-  myriad: null,
-  opinion: null,
-  metaculus: null,
-  smarkets: null,
-  mock: null,
-};
+export const DEFAULT_EXCHANGE_NAMES = [
+  "polymarket",
+  "limitless",
+  "kalshi",
+  "kalshi-demo",
+  "probable",
+  "baozi",
+  "myriad",
+  "opinion",
+  "metaculus",
+  "smarkets",
+  "rain",
+  "gemini-titan",
+  "hyperliquid",
+  "mock",
+] as const;
+
+const defaultExchanges: Record<string, any> = Object.fromEntries(
+  DEFAULT_EXCHANGE_NAMES.map((exchangeName) => [exchangeName, null]),
+);
 
 function getDefaultExchange(exchangeName: string): any {
   if (!defaultExchanges[exchangeName]) {

--- a/core/test/pipeline/default-exchanges.test.ts
+++ b/core/test/pipeline/default-exchanges.test.ts
@@ -1,0 +1,11 @@
+import { DEFAULT_EXCHANGE_NAMES } from '../../src/server/app';
+
+describe('sidecar default exchange registry', () => {
+    test('includes unauthenticated singleton entries for public Rain, Gemini Titan, and Hyperliquid reads', () => {
+        expect(DEFAULT_EXCHANGE_NAMES).toEqual(expect.arrayContaining([
+            'rain',
+            'gemini-titan',
+            'hyperliquid',
+        ]));
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `rain`, `gemini-titan`, and `hyperliquid` to the sidecar default exchange registry.
- Refactors the registry into an exported `DEFAULT_EXCHANGE_NAMES` list so coverage can be regression-tested.

Fixes #1158

## Test Plan
- `npm test --workspace=pmxt-core -- --runTestsByPath test/pipeline/default-exchanges.test.ts --runInBand` (verified RED before fix, PASS after fix)
- `npm test --workspace=pmxt-core -- --runTestsByPath test/pipeline/error-propagation.test.ts --runInBand`
- `npm run build --workspace=pmxt-core`

Note: the first local build attempt failed because dependencies were stale/missing (`@buidlrrr/rain-sdk` absent from local `node_modules`); after `npm install`, the build passed with no lockfile changes.
