### PR TITLE
fix(ts-sdk): export ClusterSortOption type

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -983,7 +983,10 @@ export interface EventMatchResult extends Readonly<UnifiedEvent> {
     marketMatches: MatchResult[];
 }
 
-export type MatchedClusterSort = 'volume' | 'confidence';
+/** Canonical cluster sort literal shared with the Python SDK. */
+export type ClusterSortOption = 'volume' | 'confidence';
+
+export type MatchedClusterSort = ClusterSortOption;
 
 /** Shared filters for matched market/event cluster discovery. */
 export interface MatchedClusterFilterParams {

--- a/sdks/typescript/tests/public-exports.test.ts
+++ b/sdks/typescript/tests/public-exports.test.ts
@@ -1,5 +1,8 @@
 import * as pmxt from '../index';
 import { FeedClient as DirectFeedClient } from '../pmxt/feed-client';
+import type { ClusterSortOption, MatchedClusterSort } from '../index';
+
+const acceptsClusterSortOption = (sort: ClusterSortOption): MatchedClusterSort => sort;
 
 describe('public exports', () => {
   it('exports FeedClient as a top-level named export', () => {
@@ -15,5 +18,11 @@ describe('public exports', () => {
   it('FeedClient is constructable from the top-level export', () => {
     const client = new pmxt.FeedClient('chainlink');
     expect(client).toBeInstanceOf(DirectFeedClient);
+  });
+
+  it('exports ClusterSortOption as a public type alias matching MatchedClusterSort', () => {
+    const byVolume = acceptsClusterSortOption('volume');
+    const byConfidence = acceptsClusterSortOption('confidence');
+    expect([byVolume, byConfidence]).toEqual(['volume', 'confidence']);
   });
 });


### PR DESCRIPTION
## Summary
- Export `ClusterSortOption` from the TypeScript SDK models to match the Python SDK's canonical cluster sort type.
- Keep `MatchedClusterSort` as an alias of `ClusterSortOption` for existing callers.
- Add a public type-export regression test.

Fixes #1169

## Test Plan
- RED: `npm test --workspace=pmxtjs -- --runInBand tests/public-exports.test.ts` failed with `Module '../index' has no exported member 'ClusterSortOption'`.
- GREEN/static: `npx tsc --noEmit --skipLibCheck --moduleResolution node --target ES2020 --module commonjs sdks/typescript/pmxt/models.ts`
- Local full public-exports Jest is blocked after the fix by missing generated SDK artifacts (`../generated/src/index.js`). Attempted `npm run generate --workspace=pmxtjs`, but this runner lacks `java` for openapi-generator.
