### PR TITLE
fix(python-sdk): export feed client support types

### DIFF
--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -22,7 +22,7 @@ from .client import Exchange
 from .constants import ENV, ENV_BASE_URL, ENV_API_KEY
 from ._exchanges import Polymarket, Limitless, Kalshi, KalshiDemo, Probable, Baozi, Myriad, Opinion, Metaculus, Smarkets, PolymarketUS, Polymarket_us, Hyperliquid, GeminiTitan, SuiBets, Suibets, Rain, Mock, Router
 from .router import Router
-from .feed_client import FeedClient
+from .feed_client import FeedClient, FeedMarket, Market, OHLCV, OracleRound, Ticker, Tickers
 from .server_manager import ServerManager
 from .errors import (
     PmxtError,
@@ -189,6 +189,12 @@ __all__ = [
     "Router",
     "Exchange",
     "FeedClient",
+    "Ticker",
+    "Tickers",
+    "OHLCV",
+    "Market",
+    "FeedMarket",
+    "OracleRound",
     "ExchangeOptions",
     "PolymarketOptions",
     "RouterOptions",

--- a/sdks/python/pmxt/feed_client.py
+++ b/sdks/python/pmxt/feed_client.py
@@ -44,6 +44,7 @@ class Ticker:
     mark_price: Optional[float] = None
 
 
+Tickers = Dict[str, Ticker]
 OHLCV = Tuple[float, float, float, float, float, float]
 
 
@@ -56,6 +57,9 @@ class Market:
     active: bool
     type: str
     info: Any = field(default_factory=dict)
+
+
+FeedMarket = Market
 
 
 @dataclass(frozen=True)

--- a/sdks/python/tests/test_public_exports.py
+++ b/sdks/python/tests/test_public_exports.py
@@ -136,6 +136,38 @@ def test_feed_client_is_top_level_public_export():
     assert "FeedClient" in public_exports
 
 
+def test_feed_client_supporting_types_are_top_level_public_exports():
+    init_path = Path(__file__).resolve().parents[1] / "pmxt" / "__init__.py"
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+
+    imported_modules = {
+        alias.asname or alias.name: node.module
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    public_exports = set()
+
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "__all__"
+            and isinstance(node.value, ast.List)
+        ):
+            public_exports.update(
+                item.value
+                for item in node.value.elts
+                if isinstance(item, ast.Constant) and isinstance(item.value, str)
+            )
+
+    expected = {"Ticker", "Tickers", "OHLCV", "Market", "FeedMarket", "OracleRound"}
+    assert expected <= imported_modules.keys()
+    assert all(imported_modules[name] == "feed_client" for name in expected)
+    assert expected <= public_exports
+
+
 def test_environment_constants_are_top_level_public_exports():
     init_path = Path(__file__).resolve().parents[1] / "pmxt" / "__init__.py"
     tree = ast.parse(init_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Export Python FeedClient support types at the package root: `Ticker`, `Tickers`, `OHLCV`, `Market`, `FeedMarket`, and `OracleRound`.
- Add a public-export regression test for the feed support types.

Fixes #1170

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/feed_client.py sdks/python/pmxt/__init__.py sdks/python/tests/test_public_exports.py`
- AST regression check that the feed support types are imported from `feed_client` and present in `__all__`
- `git diff --check`

## Notes
- `python3 -m pytest` was not available in this cron image (`No module named pip` / no pytest command), so I ran the equivalent targeted AST assertions directly.
- `npm run generate:docs --workspace=pmxt-core` produced broad unrelated API reference/config drift, so those generated files were reverted to keep this PR scoped.
