### PR TITLE
fix(core): type live numeric response fields

### DIFF
--- a/core/src/exchanges/limitless/fetcher.ts
+++ b/core/src/exchanges/limitless/fetcher.ts
@@ -22,8 +22,8 @@ export interface LimitlessRawMarket {
     };
     expirationDate?: string;
     expirationTimestamp?: number | string;
-    volumeFormatted?: number;
-    volume?: number;
+    volumeFormatted?: number | string;
+    volume?: number | string;
     logo?: string | null;
     categories?: string[];
     tags?: string[];

--- a/core/src/exchanges/probable/fetcher.ts
+++ b/core/src/exchanges/probable/fetcher.ts
@@ -22,9 +22,9 @@ export interface ProbableRawMarket {
     slug?: string;
     market_slug?: string;
     endDate?: string;
-    volume24hr?: number;
-    volume?: number;
-    liquidity?: number;
+    volume24hr?: number | string;
+    volume?: number | string;
+    liquidity?: number | string;
     icon?: string;
     category?: string;
     tags?: string[];

--- a/core/test/normalizers/exchange-normalizers-2.test.ts
+++ b/core/test/normalizers/exchange-normalizers-2.test.ts
@@ -723,6 +723,22 @@ describe('ProbableNormalizer', () => {
             expect(result.liquidity).toBe(18000);
         });
 
+        it('coerces string volume and liquidity fields from the live API to numbers', () => {
+            const result = normalizer.normalizeMarket({
+                ...rawMarket,
+                volume24hr: '4200.5',
+                volume: '95000.25',
+                liquidity: '18000.75',
+            })!;
+
+            expect(result.volume24h).toBe(4200.5);
+            expect(typeof result.volume24h).toBe('number');
+            expect(result.volume).toBe(95000.25);
+            expect(typeof result.volume).toBe('number');
+            expect(result.liquidity).toBe(18000.75);
+            expect(typeof result.liquidity).toBe('number');
+        });
+
         it('builds two outcomes from tokens array', () => {
             const result = normalizer.normalizeMarket(rawMarket)!;
             expect(result.outcomes).toHaveLength(2);

--- a/core/test/normalizers/exchange-normalizers.test.ts
+++ b/core/test/normalizers/exchange-normalizers.test.ts
@@ -152,6 +152,22 @@ describe('PolymarketNormalizer', () => {
             expect(market.liquidity).toBe(85000);
         });
 
+        it('coerces string volume and liquidity fields from Gamma to numbers', () => {
+            const result = normalizer.normalizeMarket({
+                ...rawEvent,
+                markets: [{
+                    ...rawEvent.markets![0],
+                    volume: '1200000.25',
+                    liquidity: '85000.5',
+                }],
+            } as any)!;
+
+            expect(result.volume).toBe(1200000.25);
+            expect(typeof result.volume).toBe('number');
+            expect(result.liquidity).toBe(85000.5);
+            expect(typeof result.liquidity).toBe('number');
+        });
+
         it('maps openInterest as a number', () => {
             expect(typeof market.openInterest).toBe('number');
             expect(market.openInterest).toBe(30000);
@@ -905,6 +921,19 @@ describe('LimitlessNormalizer', () => {
         it('maps volume from volume field as a number', () => {
             expect(typeof market.volume).toBe('number');
             expect(market.volume).toBe(1500000);
+        });
+
+        it('coerces string volume fields from the live API to numbers', () => {
+            const result = normalizer.normalizeMarket({
+                ...rawMarket,
+                volumeFormatted: '75000.5',
+                volume: '1500000.25',
+            });
+
+            expect(result!.volume24h).toBe(75000.5);
+            expect(typeof result!.volume24h).toBe('number');
+            expect(result!.volume).toBe(1500000.25);
+            expect(typeof result!.volume).toBe('number');
         });
 
         it('maps liquidity as a number (0 for flat market list)', () => {


### PR DESCRIPTION
## Summary
- Type Limitless live `volume` / `volumeFormatted` payload fields as `number | string`
- Type Probable live `volume24hr` / `volume` / `liquidity` payload fields as `number | string`
- Add regression coverage that Polymarket, Limitless, and Probable string numeric fields normalize to numbers

Fixes #1211
Fixes #1212
Fixes #1213

## Test Plan
- `npm test --workspace=pmxt-core -- --runTestsByPath test/normalizers/exchange-normalizers.test.ts test/normalizers/exchange-normalizers-2.test.ts` (300 passed)
- `npm run build --workspace=pmxt-core`
