### PR TITLE
fix(hyperliquid): populate volume24h; fix Kalshi error class kwargs

### DIFF
--- a/core/src/exchanges/hyperliquid/fetcher.ts
+++ b/core/src/exchanges/hyperliquid/fetcher.ts
@@ -1,7 +1,7 @@
 import { MarketFilterParams, EventFetchParams, OHLCVParams, TradesParams } from '../../BaseExchange';
 import { IExchangeFetcher, FetcherContext } from '../interfaces';
 import { hyperliquidErrorMapper } from './errors';
-import { toCoinNotation, toMidKey, fromMarketId } from './utils';
+import { toCoinNotation, toMidKey, fromMarketId, fromCoinEncoding } from './utils';
 
 // ----------------------------------------------------------------------------
 // Raw venue-native types (Hyperliquid HIP-4 Outcome Markets)
@@ -142,11 +142,21 @@ export interface HyperliquidRawUserState {
     withdrawable: string;
 }
 
+// Per-coin context from spotMetaAndAssetCtxs (only the fields we use)
+export interface HyperliquidRawSpotAssetCtx {
+    coin: string;            // "#NNNN" for outcome legs
+    dayNtlVlm: string;       // 24h notional volume in USDC
+    prevDayPx?: string;
+    markPx?: string;
+    midPx?: string;
+}
+
 // Composite type: outcome + its question context
 export interface HyperliquidRawOutcomeWithQuestion {
     outcome: HyperliquidRawOutcome;
     question: HyperliquidRawQuestion | undefined;
     midPrice: string | undefined; // from allMids
+    volume24h?: number;           // summed Yes+No dayNtlVlm from spotMetaAndAssetCtxs
 }
 
 // ----------------------------------------------------------------------------
@@ -176,9 +186,10 @@ export class HyperliquidFetcher implements IExchangeFetcher<HyperliquidRawOutcom
     // -- Markets (outcomes) ----------------------------------------------------
 
     async fetchRawMarkets(params?: MarketFilterParams): Promise<HyperliquidRawOutcomeWithQuestion[]> {
-        const [meta, mids] = await Promise.all([
+        const [meta, mids, volumeMap] = await Promise.all([
             this.fetchOutcomeMeta(),
             this.fetchAllMids(),
+            this.fetchOutcomeVolumeMap(),
         ]);
 
         const questionMap = new Map<number, HyperliquidRawQuestion>();
@@ -192,6 +203,7 @@ export class HyperliquidFetcher implements IExchangeFetcher<HyperliquidRawOutcom
             outcome,
             question: questionMap.get(outcome.outcome),
             midPrice: this.getMidForOutcome(mids, outcome.outcome),
+            volume24h: volumeMap.get(outcome.outcome),
         }));
 
         // Filter settled outcomes out by default (active only)
@@ -311,6 +323,32 @@ export class HyperliquidFetcher implements IExchangeFetcher<HyperliquidRawOutcom
 
     async fetchAllMids(): Promise<HyperliquidRawMid> {
         return this.postInfo<HyperliquidRawMid>({ type: 'allMids' });
+    }
+
+    /**
+     * Build a map of outcomeId -> 24h notional volume (Yes leg + No leg)
+     * by reading spotMetaAndAssetCtxs, where outcome legs appear as
+     * coin "#<encoding>" with `dayNtlVlm` in USDC.
+     */
+    async fetchOutcomeVolumeMap(): Promise<Map<number, number>> {
+        const map = new Map<number, number>();
+        try {
+            const resp = await this.postInfo<[unknown, HyperliquidRawSpotAssetCtx[]]>({ type: 'spotMetaAndAssetCtxs' });
+            const ctxs = Array.isArray(resp) ? resp[1] : undefined;
+            if (!Array.isArray(ctxs)) return map;
+            for (const ctx of ctxs) {
+                if (!ctx?.coin || !ctx.coin.startsWith('#')) continue;
+                const vol = parseFloat(ctx.dayNtlVlm);
+                if (!Number.isFinite(vol)) continue;
+                const encoding = parseInt(ctx.coin.slice(1), 10);
+                if (!Number.isFinite(encoding)) continue;
+                const { outcomeId } = fromCoinEncoding(encoding);
+                map.set(outcomeId, (map.get(outcomeId) ?? 0) + vol);
+            }
+        } catch {
+            // ponytail: best-effort volume enrichment; if spotMetaAndAssetCtxs is unreachable, return empty map and callers fall back to 0
+        }
+        return map;
     }
 
     private getMidForOutcome(mids: HyperliquidRawMid, outcomeId: number): string | undefined {

--- a/core/src/exchanges/hyperliquid/index.ts
+++ b/core/src/exchanges/hyperliquid/index.ts
@@ -126,14 +126,15 @@ export class HyperliquidExchange extends PredictionMarketExchange {
             return [];
         }
 
-        const [rawQuestions, meta, mids] = await Promise.all([
+        const [rawQuestions, meta, mids, volumeMap] = await Promise.all([
             this.fetcher.fetchRawEvents(params),
             this.fetcher.fetchOutcomeMeta(),
             this.fetcher.fetchAllMids(),
+            this.fetcher.fetchOutcomeVolumeMap(),
         ]);
 
         return rawQuestions
-            .map(q => this.normalizer.normalizeEventWithMarkets(q, meta, mids))
+            .map(q => this.normalizer.normalizeEventWithMarkets(q, meta, mids, volumeMap))
             .filter((e): e is UnifiedEvent => e !== null);
     }
 

--- a/core/src/exchanges/hyperliquid/normalizer.ts
+++ b/core/src/exchanges/hyperliquid/normalizer.ts
@@ -233,7 +233,7 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
             slug: `hl-${outcomeId}`,
             outcomes,
             resolutionDate: expiryDate ?? new Date(0),
-            volume24h: 0,
+            volume24h: raw.volume24h ?? 0,
             liquidity: 0,
             url: buildMarketUrl(outcomeId),
             category,
@@ -290,6 +290,7 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
         raw: HyperliquidRawQuestion,
         outcomeMeta: HyperliquidRawOutcomeMeta,
         mids: HyperliquidRawMid,
+        volumeMap?: Map<number, number>,
     ): UnifiedEvent | null {
         const event = this.normalizeEvent(raw);
         if (!event) return null;
@@ -308,6 +309,7 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
                 outcome,
                 question: raw,
                 midPrice,
+                volume24h: volumeMap?.get(outcomeId),
             });
             if (market) {
                 markets.push(market);

--- a/sdks/python/pmxt/errors.py
+++ b/sdks/python/pmxt/errors.py
@@ -114,15 +114,19 @@ class ValidationError(PmxtError):
 class NetworkError(PmxtError):
     """503 Service Unavailable - Network connectivity issues."""
 
-    def __init__(self, message: str, exchange: str | None = None):
-        super().__init__(message, code="NETWORK_ERROR", retryable=True, exchange=exchange)
+    def __init__(self, message: str, exchange: str | None = None, **kwargs: Any) -> None:
+        kwargs.setdefault("code", "NETWORK_ERROR")
+        kwargs.setdefault("retryable", True)
+        super().__init__(message, exchange=exchange, **kwargs)
 
 
 class ExchangeNotAvailable(PmxtError):
     """503 Service Unavailable - Exchange is down or unreachable."""
 
-    def __init__(self, message: str, exchange: str | None = None):
-        super().__init__(message, code="EXCHANGE_NOT_AVAILABLE", retryable=True, exchange=exchange)
+    def __init__(self, message: str, exchange: str | None = None, **kwargs: Any) -> None:
+        kwargs.setdefault("code", "EXCHANGE_NOT_AVAILABLE")
+        kwargs.setdefault("retryable", True)
+        super().__init__(message, exchange=exchange, **kwargs)
 
 
 # Mapping from server error codes to error classes


### PR DESCRIPTION
## Summary
**Hyperliquid `volume24h` was hardcoded to 0** in `normalizer.ts` for every market and event. Fixed by pulling `dayNtlVlm` from `spotMetaAndAssetCtxs` (where outcome legs appear as `coin: '#NNNN'`), summing Yes+No notional per outcome, and threading the map through `fetchRawMarkets` / `fetchEventsImpl`. One extra batched call, no N+1.

**Python SDK Kalshi crash**: `NetworkError` / `ExchangeNotAvailable` `__init__` signatures rejected the `code`/`retryable` kwargs that `from_server_error` always passes. Any 503 raised `TypeError: ExchangeNotAvailable.__init__() got an unexpected keyword argument 'code'` instead of a typed `PmxtError`. Both classes now accept `**kwargs` and default-fill their hardcoded values.

## Verified locally via Python SDK against `npm run server`
`fetch_events(exchange='hyperliquid', query='World Cup', limit=8)`:
```
$2,211,178  2026 World Cup Champion
$  761,324  World Cup: Spain vs Saudi Arabia
$  400,211  World Cup: Uruguay vs Cape Verde
$  387,893  World Cup: Belgium vs Iran
$  337,734  World Cup: New Zealand vs Egypt
...
```

Top HL markets by `volume24h`:
```
$483,017  Netherlands
$419,547  Germany
$386,582  BTC > $64,223 @ 2026-06-22 06:00 UTC
$356,995  Spain
$261,684  Japan
```

`fetch_events(exchange='kalshi', query='Trump')` no longer raises.

## Test plan
- [ ] CI passes
- [ ] After deploy, hosted MCP returns non-zero `volume24h` for active HL markets
- [ ] Hosted MCP returns typed errors (not 500) when Kalshi or another venue is briefly unavailable