### PR TITLE
fix(sdks): HL fromMarketId accepts outcome tokens; add fetchEventsPaginated

### DIFF
--- a/core/src/exchanges/hyperliquid/utils.ts
+++ b/core/src/exchanges/hyperliquid/utils.ts
@@ -71,14 +71,26 @@ export function toMarketId(outcomeId: number): string {
 }
 
 /**
- * Extract the numeric outcome ID from our market ID format.
+ * Extract the numeric outcome ID from a Hyperliquid identifier.
+ *
+ * Accepts either:
+ *   - our canonical market ID, "hl-outcome-{N}"
+ *   - a raw encoded asset token (numeric string >= OUTCOME_ASSET_BASE),
+ *     as returned in UnifiedMarket.outcomes[].outcomeId. Decoded via
+ *     decodeAssetId so callers can pass an outcome token directly.
  */
 export function fromMarketId(marketId: string): number {
     const match = marketId.match(/^hl-outcome-(\d+)$/);
-    if (!match) {
-        throw new Error(`Invalid Hyperliquid market ID: ${marketId}`);
+    if (match) {
+        return parseInt(match[1], 10);
     }
-    return parseInt(match[1], 10);
+    if (/^\d+$/.test(marketId)) {
+        const assetId = parseInt(marketId, 10);
+        if (assetId >= OUTCOME_ASSET_BASE) {
+            return decodeAssetId(assetId).outcomeId;
+        }
+    }
+    throw new Error(`Invalid Hyperliquid market ID: ${marketId}`);
 }
 
 /**

--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -1346,6 +1346,33 @@ class Exchange(ABC):
         except ApiException as e:
             raise self._parse_api_exception(e) from None
 
+    def fetch_events_paginated(self, params: Optional[dict] = None, **kwargs) -> PaginatedEventsResult:
+        try:
+            args = []
+            if kwargs:
+                params = {**(params or {}), **kwargs}
+            if params is not None:
+                args.append(_convert_params_to_camel(params))
+            body: dict = {"args": args}
+            creds = self._get_credentials_dict()
+            if creds:
+                body["credentials"] = creds
+            url = f"{self._resolve_sidecar_host()}/api/{self.exchange_name}/fetchEventsPaginated"
+            headers = {"Content-Type": "application/json", "Accept": "application/json"}
+            headers.update(self._get_auth_headers())
+            response = self._fetch_with_retry(
+                lambda: self._api_client.call_api(method="POST", url=url, body=body, header_params=headers)
+            )
+            response.read()
+            data = self._handle_response(json.loads(response.data))
+            return PaginatedEventsResult(
+                data=[_convert_event(e) for e in data.get("data", [])],
+                total=data.get("total"),
+                next_cursor=data.get("nextCursor"),
+            )
+        except ApiException as e:
+            raise self._parse_api_exception(e) from None
+
     def fetch_events(self, params: Optional[dict] = None, **kwargs) -> List[UnifiedEvent]:
         try:
             args = []

--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -963,6 +963,36 @@ export abstract class Exchange {
         }
     }
 
+    async fetchEventsPaginated(params?: any): Promise<PaginatedEventsResult> {
+        await this.initPromise;
+        try {
+            const args: any[] = [];
+            if (params !== undefined) args.push(params);
+            const response = await this.fetchWithRetry(`${this.resolveBaseUrl()}/api/${this.exchangeName}/fetchEventsPaginated`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
+                body: JSON.stringify({ args, credentials: this.getCredentials() }),
+            });
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                if (body.error && typeof body.error === "object") {
+                    throw fromServerError(body.error);
+                }
+                throw new PmxtError(body.error?.message || response.statusText);
+            }
+            const json = await response.json();
+            const data = this.handleResponse(json);
+            return {
+                data: (data.data || []).map(convertEvent),
+                total: data.total,
+                nextCursor: data.nextCursor,
+            };
+        } catch (error) {
+            if (error instanceof PmxtError) throw error;
+            throw new PmxtError(`Failed to fetchEventsPaginated: ${error}`);
+        }
+    }
+
     async fetchEvents(params?: EventFetchParams): Promise<UnifiedEvent[]> {
         await this.initPromise;
         try {


### PR DESCRIPTION
## Summary
Two fixes uncovered by the HL SDK matrix audit:

1. **HL `fetchOrderBook`/`fetchOHLCV`/`fetchTrades` rejected real outcome tokens.** The param is named `outcomeId` but the handler only accepted the canonical `hl-outcome-{N}` form. Passing an actual outcome token (e.g. `100002000`, as returned by `UnifiedMarket.outcomes[].outcomeId`) threw `Invalid Hyperliquid market ID: 100002000`. `fromMarketId()` now accepts either form via `decodeAssetId`.

2. **`fetchEventsPaginated` was missing from both SDKs.** `BaseExchange.fetchEventsPaginated` existed but neither `client.py` nor `client.ts` exposed a wrapper. Added `fetch_events_paginated` / `fetchEventsPaginated` mirroring the existing `fetchMarketsPaginated` pattern.

## Verified locally (Python + TS) against `npm run server`
```
fetchEventsPaginated         OK
fetchOrderBook(outcomeTok)   OK
fetchOHLCV(outcomeTok)       OK
fetchTrades(outcomeTok)      OK
```

## Not in scope (reminder, untested without creds)
fetchBalance, fetchPositions, fetchOpenOrders, fetchMyTrades, fetchClosedOrders, fetchAllOrders, fetchOrder, cancelOrder, submitOrder, createOrder.