### PR TITLE
feat(hyperliquid): implement fetchOrderBooks via client-side loop

### DIFF
--- a/core/src/exchanges/hyperliquid/index.ts
+++ b/core/src/exchanges/hyperliquid/index.ts
@@ -146,6 +146,15 @@ export class HyperliquidExchange extends PredictionMarketExchange {
         return this.normalizer.normalizeOrderBook(raw, outcomeId);
     }
 
+    // ponytail: Hyperliquid has no native batch order-book endpoint; loop client-side.
+    // Add a concurrency cap if rate limits start biting in practice.
+    async fetchOrderBooks(outcomeIds: string[]): Promise<Record<string, OrderBook>> {
+        const entries = await Promise.all(
+            outcomeIds.map(async id => [id, await this.fetchOrderBook(id)] as const),
+        );
+        return Object.fromEntries(entries);
+    }
+
     async fetchOHLCV(outcomeId: string, params: OHLCVParams = { resolution: '1h' }): Promise<PriceCandle[]> {
         const raw = await this.fetcher.fetchRawOHLCV(outcomeId, params);
         return this.normalizer.normalizeOHLCV(raw, params);


### PR DESCRIPTION
## Summary
HL has no native batch order-book endpoint, so `fetchOrderBooks` threw \"Method not supported\". Implemented as `Promise.all` over `fetchOrderBook` — inherits the outcome-token-or-marketId resolution from the single-fetch path. The `has.fetchOrderBooks` capability auto-flips to true because `BaseExchange._deriveCapabilities` introspects overrides.

A `ponytail:` comment marks the unbounded concurrency: add a cap if HL info rate limits start biting in practice.

## Verified locally (Python + TS) against `npm run server`
```
hl.fetchOrderBooks(['hl-outcome-171','hl-outcome-172','hl-outcome-173'])
  -> 3 books (171: empty, 172: 4 bids / 9 asks, 173: 20/20)
mixed marketId + outcomeToken: 2 books returned
```