### PR TITLE
feat(hyperliquid): populate UserTrade marketId/outcomeId/fee; synthesize closed+all orders

### DIFF
--- a/core/src/exchanges/hyperliquid/index.ts
+++ b/core/src/exchanges/hyperliquid/index.ts
@@ -199,6 +199,35 @@ export class HyperliquidExchange extends PredictionMarketExchange {
             .map((f, i) => this.normalizer.normalizeUserTrade(f, i));
     }
 
+    // ponytail: HL exposes no "closed orders" endpoint, only userFills + openOrders.
+    // Synthesize closed orders as: oids seen in fills that are not currently open.
+    // Caveat — this surfaces *filled* orders, not *cancelled-with-no-fills* (HL drops those from public history).
+    async fetchClosedOrders(): Promise<Order[]> {
+        const wallet = this.requireWallet();
+        const [rawFills, rawOpen] = await Promise.all([
+            this.fetcher.fetchRawUserFills(wallet),
+            this.fetcher.fetchRawOpenOrders(wallet),
+        ]);
+        const openOids = new Set(rawOpen.map(o => o.oid));
+        const byOid = new Map<number, typeof rawFills>();
+        for (const f of rawFills) {
+            if (!f.coin.startsWith('#')) continue;
+            if (openOids.has(f.oid)) continue;
+            const list = byOid.get(f.oid) ?? [];
+            list.push(f);
+            byOid.set(f.oid, list);
+        }
+        return [...byOid.values()].map(fills => this.normalizer.synthesizeClosedOrder(fills));
+    }
+
+    async fetchAllOrders(): Promise<Order[]> {
+        const [open, closed] = await Promise.all([
+            this.fetchOpenOrders(),
+            this.fetchClosedOrders(),
+        ]);
+        return [...open, ...closed];
+    }
+
     // -------------------------------------------------------------------------
     // Trading (EIP-712 signing required)
     // -------------------------------------------------------------------------

--- a/core/src/exchanges/hyperliquid/normalizer.ts
+++ b/core/src/exchanges/hyperliquid/normalizer.ts
@@ -367,6 +367,7 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
     }
 
     normalizeUserTrade(raw: HyperliquidRawFill, _index: number): UserTrade {
+        const fee = parseFloat(raw.fee);
         return {
             id: String(raw.tid),
             timestamp: raw.time,
@@ -374,6 +375,43 @@ export class HyperliquidNormalizer implements IExchangeNormalizer<HyperliquidRaw
             amount: parseFloat(raw.sz),
             side: raw.side === 'B' ? 'buy' : raw.side === 'A' ? 'sell' : 'unknown',
             orderId: String(raw.oid),
+            marketId: this.coinToMarketId(raw.coin),
+            outcomeId: this.coinToOutcomeId(raw.coin),
+            fee: Number.isFinite(fee) ? fee : undefined,
+        };
+    }
+
+    // ponytail: HL has no closed-orders endpoint; we reconstruct from the fills of one oid.
+    // amount = filled (we cannot recover the unfilled-then-cancelled portion); price = VWAP across fills.
+    synthesizeClosedOrder(fills: HyperliquidRawFill[]): Order {
+        const first = fills[0];
+        let totalSz = 0;
+        let totalNotional = 0;
+        let totalFee = 0;
+        let earliest = first.time;
+        for (const f of fills) {
+            const sz = parseFloat(f.sz);
+            const px = parseFloat(f.px);
+            const fee = parseFloat(f.fee);
+            totalSz += sz;
+            totalNotional += sz * px;
+            if (Number.isFinite(fee)) totalFee += fee;
+            if (f.time < earliest) earliest = f.time;
+        }
+        const vwap = totalSz > 0 ? totalNotional / totalSz : parseFloat(first.px);
+        return {
+            id: String(first.oid),
+            marketId: this.coinToMarketId(first.coin),
+            outcomeId: this.coinToOutcomeId(first.coin),
+            side: first.side === 'B' ? 'buy' : 'sell',
+            type: 'limit',
+            price: vwap,
+            amount: totalSz,
+            status: 'filled',
+            filled: totalSz,
+            remaining: 0,
+            timestamp: earliest,
+            fee: totalFee,
         };
     }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -209,6 +209,10 @@ export interface Trade {
 export interface UserTrade extends Trade {
     /** The order that produced this trade, if known. */
     orderId?: string;
+    /** The market this trade belongs to, when the venue exposes it (e.g. derivable from the fill's coin/asset). */
+    marketId?: string;
+    /** Trading fee paid by the user for this fill, when the venue exposes it. */
+    fee?: number;
     /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */
     txHash?: string | null;
     /** Populated in hosted mode after on-chain settlement; null for local-mode and for non-on-chain venues. */


### PR DESCRIPTION
## Summary
Two HL gaps surfaced by ground-truth assertion checks against real active wallets:

### UserTrade enrichment
- `Trade.outcomeId` and new `UserTrade.marketId` / `UserTrade.fee` are now populated by HL's `normalizeUserTrade` from `raw.coin` and `raw.fee`. Previously every HL fill came back with `marketId=null`, `outcomeId=null`, `fee=null` — consumers couldn't tell which market a fill was on.
- Wired through existing `coinToMarketId` / `coinToOutcomeId` helpers (same ones used by `normalizeOpenOrder`).

### Closed + all orders
- HL exposes no closed-orders endpoint. `fetchClosedOrders` now synthesizes by grouping `userFills` by `oid` and excluding currently-open oids. VWAP price, summed size for amount/filled, summed fee, earliest fill time as timestamp.
- `fetchAllOrders = openOrders ∪ closedOrders`.
- `ponytail:` comment marks the limitation: cancelled-with-no-fills orders aren't reconstructable from the public info API.

## Verified (Python + TS, ground-truth against HL raw API)

Wallet `0x6476…` (2000 fills): both SDKs return 2000/2000 trades with marketId / outcomeId / fee populated, identical sample.

Wallet `0x5af8…` (7 open, 104 unique fill-only oids):
```
fetchClosedOrders → 104 (matches raw expected count exactly)
fetchAllOrders    → 111 = 7 open + 104 closed
sample closed: id=474427504352 market=hl-outcome-207 side=buy status=filled
               amount=13 filled=13 remaining=0 price=0.00012 fee=0
```
Identical on both SDKs.