### PR TITLE
fix(core): accept address websocket subscriptions

### DIFF
--- a/core/src/server/ws-handler.ts
+++ b/core/src/server/ws-handler.ts
@@ -103,6 +103,7 @@ const WATCH_METHODS = new Set([
   "watchOrderBook",
   "watchOrderBooks",
   "watchTrades",
+  "watchAddress",
 ]);
 
 /** Data-feed methods that produce streaming data. */
@@ -113,6 +114,7 @@ const FEED_WATCH_METHODS = new Set([
 /** Methods for unsubscribing. */
 const UNWATCH_METHODS: Record<string, string> = {
   unwatchOrderBook: "watchOrderBook",
+  unwatchAddress: "watchAddress",
 };
 
 function send(ws: WebSocket, msg: ServerEvent): void {

--- a/core/test/pipeline/ws-handler-streaming-methods.test.ts
+++ b/core/test/pipeline/ws-handler-streaming-methods.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function read(relativePath: string): string {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('WebSocket streaming method registry', () => {
+    it('accepts every exchange method declared with the ws verb', () => {
+        const methodVerbConfig = JSON.parse(read('core/src/server/method-verbs.json')) as Record<string, { verb?: string }>;
+        const wsHandler = read('core/src/server/ws-handler.ts');
+
+        const registeredMethodNames = new Set(
+            Array.from(wsHandler.matchAll(/(?:["'])(watch[A-Za-z]+|unwatch[A-Za-z]+)(?:["'])|\b(unwatch[A-Za-z]+)\s*:/g))
+                .map((match) => match[1] || match[2])
+                .filter(Boolean),
+        );
+        const wsMethods = Object.entries(methodVerbConfig)
+            .filter(([, config]) => config.verb === 'ws')
+            .map(([method]) => method);
+
+        expect(wsMethods.filter((method) => !registeredMethodNames.has(method))).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Add `watchAddress` to the sidecar WebSocket streaming allowlist.
- Map `unwatchAddress` back to `watchAddress` for subscription-key lookup during unsubscribe.
- Add a regression test that checks all exchange methods declared as `verb: "ws"` in `method-verbs.json` are registered by the WebSocket handler.

Fixes #1177

## Test Plan
- `npm test --workspace=pmxt-core -- --runTestsByPath test/pipeline/ws-handler-streaming-methods.test.ts --runInBand`
- `npm test --workspace=pmxt-core -- --runTestsByPath test/pipeline/watch-order-book-api.test.ts test/pipeline/get-post-parity.test.ts --runInBand`
- `npm run build --workspace=pmxt-core`
- `git diff --check`
