### PR TITLE
fix(python-sdk): log silent sidecar cleanup failures

### DIFF
--- a/sdks/python/pmxt/client.py
+++ b/sdks/python/pmxt/client.py
@@ -6,6 +6,7 @@ OpenAPI client, matching the JavaScript API exactly.
 """
 
 import json
+import logging
 import os
 import re
 import sys
@@ -25,6 +26,9 @@ if _GENERATED_PATH not in sys.path:
 from pmxt_internal import ApiClient, Configuration
 from pmxt_internal.api.default_api import DefaultApi
 from pmxt_internal.exceptions import ApiException
+
+
+logger = logging.getLogger(__name__)
 
 from .models import (
     UnifiedMarket,
@@ -461,8 +465,8 @@ class Exchange(ABC):
                         return error_detail.get("message", str(e))
                     elif isinstance(error_detail, str):
                         return error_detail
-            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-                pass
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                logger.debug("Unable to parse PMXT API error response body", exc_info=exc)
         return str(e)
 
     def _parse_api_exception(self, e: Exception) -> PmxtError:

--- a/sdks/python/pmxt/server_manager.py
+++ b/sdks/python/pmxt/server_manager.py
@@ -15,6 +15,7 @@ This ensures zero-configuration usage across all SDKs.
 
 import os
 import json
+import logging
 import time
 import subprocess
 import shutil
@@ -23,6 +24,9 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any
 import urllib.request
 import urllib.error
+
+
+logger = logging.getLogger(__name__)
 
 
 class ServerManager:
@@ -153,8 +157,8 @@ class ServerManager:
                     # This allows 1.0.0 and 1.0.0-b4 to coexist in dev
                     if expected_base != server_base:
                         return True
-            except (OSError, json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError):
-                pass
+            except (OSError, json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError) as exc:
+                logger.debug("Unable to compare sidecar server version", exc_info=exc)
 
         return False
 
@@ -289,13 +293,13 @@ class ServerManager:
                     pid = int(line.strip())
                     try:
                         os.kill(pid, _signal.SIGTERM)
-                    except (OSError, ProcessLookupError):
-                        pass
+                    except (OSError, ProcessLookupError) as exc:
+                        logger.debug("Unable to terminate orphaned PMXT sidecar pid %s", pid, exc_info=exc)
 
                 if result.stdout.strip():
                     time.sleep(0.5)
-        except (OSError, subprocess.TimeoutExpired, ValueError):
-            pass
+        except (OSError, subprocess.TimeoutExpired, ValueError) as exc:
+            logger.debug("Unable to scan or terminate orphaned PMXT sidecars", exc_info=exc)
 
     def _kill_old_server(self) -> None:
         """Kill the currently running server (Internal)."""
@@ -312,8 +316,8 @@ class ServerManager:
                     import signal
                     os.kill(pid, signal.SIGTERM)
                 time.sleep(0.5)
-            except (OSError, subprocess.TimeoutExpired):
-                pass
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                logger.debug("Unable to terminate PMXT sidecar pid %s", pid, exc_info=exc)
 
             # Verify the process is actually dead; escalate to SIGKILL if not
             if os.name != 'nt':


### PR DESCRIPTION
## Summary
- Replace silent `pass` handlers in the Python SDK sidecar manager with debug logging.
- Add debug logging when API error body parsing falls back to the original exception string.

Fixes #1256
Fixes #1257
Fixes #1258
Fixes #1259
Fixes #1260

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/server_manager.py sdks/python/pmxt/client.py`
- `git diff --check`

## Notes
- This is a focused Python SDK observability fix; no generated client or API surface changes are intended.
