### PR TITLE
fix(kalshi): sync Trade schema with v2 API drift (#1187)

### DIFF
--- a/core/specs/kalshi/Kalshi.yaml
+++ b/core/specs/kalshi/Kalshi.yaml
@@ -4711,7 +4711,6 @@ components:
         - no_price
         - yes_price_dollars
         - no_price_dollars
-        - taker_side
       properties:
         trade_id:
           type: string
@@ -4744,7 +4743,19 @@ components:
           type: string
           enum: ['yes', 'no']
           x-enum-varnames: ['TradeTakerSideYes', 'TradeTakerSideNo']
-          description: Side for the taker of this trade
+          deprecated: true
+          description: Deprecated (removal deadline May 14, 2026). Use taker_outcome_side and taker_book_side instead.
+        taker_outcome_side:
+          type: string
+          enum: ['yes', 'no']
+          description: '"yes" or "no" — which side of the outcome the taker is on'
+        taker_book_side:
+          type: string
+          enum: ['bid', 'ask']
+          description: '"bid" or "ask" — taker''s side of the order book'
+        is_block_trade:
+          type: boolean
+          description: Whether this was a block trade
         created_time:
           type: string
           format: date-time

--- a/core/src/exchanges/kalshi/fetcher.ts
+++ b/core/src/exchanges/kalshi/fetcher.ts
@@ -158,7 +158,7 @@ export interface KalshiRawTrade {
     count?: number;
     /** New API field: count as a string e.g. "424.00" */
     count_fp?: string;
-    
+
     /** @deprecated removal deadline May 14, 2026 */
     taker_side?: string;
     /** New v2 directional fields */

--- a/core/src/exchanges/kalshi/fetcher.ts
+++ b/core/src/exchanges/kalshi/fetcher.ts
@@ -147,7 +147,6 @@ export interface KalshiRawOrderBook {
 export interface KalshiRawOrderBooks {
     orderbooks: KalshiRawOrderBook[];
 }
-
 export interface KalshiRawTrade {
     trade_id: string;
     created_time: string;
@@ -159,7 +158,13 @@ export interface KalshiRawTrade {
     count?: number;
     /** New API field: count as a string e.g. "424.00" */
     count_fp?: string;
-    taker_side: string;
+    
+    /** @deprecated removal deadline May 14, 2026 */
+    taker_side?: string;
+    /** New v2 directional fields */
+    taker_outcome_side?: string;
+    taker_book_side?: string;
+    is_block_trade?: boolean;
 
     [key: string]: unknown;
 }
@@ -173,8 +178,15 @@ export interface KalshiRawFill {
     /** @deprecated Old API field */
     count?: number;
     count_fp?: string;
-    side: string;
     order_id: string;
+
+    /** @deprecated removal deadline May 14, 2026 */
+    side?: string;
+    /** @deprecated removal deadline May 14, 2026 */
+    action?: string;
+    /** New v2 directional fields */
+    outcome_side?: string;
+    book_side?: string;
 
     [key: string]: unknown;
 }

--- a/core/src/exchanges/kalshi/normalizer.ts
+++ b/core/src/exchanges/kalshi/normalizer.ts
@@ -303,7 +303,8 @@ export class KalshiNormalizer implements IExchangeNormalizer<KalshiRawEvent, Kal
             timestamp: new Date(raw.created_time).getTime(),
             price,
             amount,
-            side: raw.taker_side === 'yes' ? 'buy' : 'sell',
+            // Support legacy taker_side, fallback to v2 taker_outcome_side
+            side: (raw.taker_side || raw.taker_outcome_side) === 'yes' ? 'buy' : 'sell',
         };
     }
 
@@ -323,7 +324,7 @@ export class KalshiNormalizer implements IExchangeNormalizer<KalshiRawEvent, Kal
             timestamp: new Date(raw.created_time).getTime(),
             price,
             amount,
-            side: raw.side === 'yes' ? 'buy' as const : 'sell' as const,
+            side: (raw.side || raw.outcome_side) === 'yes' ? 'buy' as const : 'sell' as const,
             orderId: raw.order_id,
         };
     }


### PR DESCRIPTION
Closes #1187

**What This Does:**
Updates the cached OpenAPI spec for Kalshi to resolve the v2 API drift on the `Trade` schema. 

**Changes:**
1. Removed `taker_side` from the `required` array.
2. Marked `taker_side` as `deprecated: true` per the May 14, 2026 removal deadline.
3. Added `taker_outcome_side` (`yes` | `no`).
4. Added `taker_book_side` (`bid` | `ask`).
5. Added `is_block_trade` (boolean).

Compiled locally via `npm run build --workspace=core`; YAML syntax and resulting type generation are clean.