### PR TITLE
fix(ts-sdk): validate hosted limit order price

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -2514,6 +2514,9 @@ export abstract class Exchange {
         if (!(Number(params.amount) > 0)) {
             throw new InvalidOrder("amount must be positive");
         }
+        if (orderType !== "market" && !(Number(params.price) > 0)) {
+            throw new InvalidOrder("limit orders require a positive price");
+        }
 
         // to6dec throws InvalidOrder for sub-micro precision.
         const amount6dec = to6dec(params.amount as number).toString();

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -351,6 +351,32 @@ describe("hosted write dispatch", () => {
     expect("market_id" in body).toBe(false);
   });
 
+  it("buildOrder rejects limit orders without a positive price before dispatch", async () => {
+    const spy = installFetchSpy(() => jsonResponse(buildResponsePayload("buy")));
+    const api = makePolymarket({ withSigner: true });
+
+    await expect(
+      api.buildOrder({
+        outcomeId: "22222222-2222-4222-8222-222222222222",
+        side: "buy",
+        type: "limit",
+        amount: 5,
+        denom: "shares",
+      } as any),
+    ).rejects.toThrow("limit orders require a positive price");
+    await expect(
+      api.buildOrder({
+        outcomeId: "22222222-2222-4222-8222-222222222222",
+        side: "buy",
+        type: "limit",
+        amount: 5,
+        denom: "shares",
+        price: 0,
+      } as any),
+    ).rejects.toThrow("limit orders require a positive price");
+    expect(captured(spy)).toHaveLength(0);
+  });
+
   it("cancelOrder → POST cancel/build then POST cancel", async () => {
     let call = 0;
     const spy = installFetchSpy(() => {


### PR DESCRIPTION
## Summary
- Add TypeScript hosted `buildOrder` validation for limit-order `price` presence and positivity.
- Cover missing/zero limit prices with a regression test that verifies no hosted request is dispatched.

Fixes #1287

## Test Plan
- `npm test -- --runTestsByPath tests/hosted-dispatch.test.ts -t "positive price" --runInBand` (pass; used local untracked `generated/src` stubs because this checkout cannot regenerate TypeScript OpenAPI output: `java` is unavailable)
- `npm test -- --runTestsByPath tests/hosted-dispatch.test.ts --runInBand` (blocked by pre-existing/local generated-stub limitations outside this change: `fetchBalance` empty stub response and `NotSupported` instanceof mismatch)
- `npm run generate:sdk:typescript --workspace=pmxt-core` (blocked locally: `java: not found`)
- `git diff --check`
