### PR TITLE
fix(ts-sdk): accept deprecated ids for watchOrderBooks

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -1900,12 +1900,25 @@ export abstract class Exchange {
      * ```
      */
     async watchOrderBooks(
-        outcomeIds: (string | MarketOutcome)[],
+        outcomeIds?: (string | MarketOutcome)[] | { ids?: (string | MarketOutcome)[] },
         limit?: number,
         params: Record<string, any> = {},
     ): Promise<Record<string, OrderBook>> {
         await this.initPromise;
-        const resolvedIds = outcomeIds.map(resolveOutcomeId);
+        let effectiveOutcomeIds = outcomeIds;
+        if (Array.isArray((outcomeIds as { ids?: unknown })?.ids)) {
+            console.warn("Parameter 'ids' is deprecated, use 'outcomeIds' instead.");
+            effectiveOutcomeIds = (outcomeIds as { ids: (string | MarketOutcome)[] }).ids;
+        } else if (effectiveOutcomeIds === undefined && Array.isArray(params.ids)) {
+            console.warn("Parameter 'ids' is deprecated, use 'outcomeIds' instead.");
+            effectiveOutcomeIds = params.ids as (string | MarketOutcome)[];
+            const { ids: _deprecatedIds, ...restParams } = params;
+            params = restParams;
+        }
+        if (!Array.isArray(effectiveOutcomeIds)) {
+            throw new TypeError("Missing required argument: 'outcomeIds'");
+        }
+        const resolvedIds = effectiveOutcomeIds.map(resolveOutcomeId);
         const args: any[] = [resolvedIds];
         if (limit !== undefined) {
             args.push(limit);

--- a/sdks/typescript/tests/watch-order-books-compat.test.ts
+++ b/sdks/typescript/tests/watch-order-books-compat.test.ts
@@ -1,0 +1,40 @@
+import { Polymarket } from "../pmxt/client";
+
+function makeClientWithWs(capturedArgs: unknown[][]): Polymarket {
+  const client = new Polymarket({ autoStartServer: false }) as any;
+  client.getOrCreateWs = async () => ({
+    subscribeBatch: async (_exchange: unknown, _method: unknown, args: unknown[]) => {
+      capturedArgs.push(args as unknown[]);
+      return { "outcome-1": { bids: [], asks: [] } };
+    },
+  });
+  return client;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("watchOrderBooks deprecated ids compatibility", () => {
+  it("accepts an ids object as a backwards-compatible alias", async () => {
+    const capturedArgs: unknown[][] = [];
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = makeClientWithWs(capturedArgs);
+
+    await client.watchOrderBooks({ ids: ["outcome-1"] });
+
+    expect(warn).toHaveBeenCalledWith("Parameter 'ids' is deprecated, use 'outcomeIds' instead.");
+    expect(capturedArgs[0]).toEqual([["outcome-1"]]);
+  });
+
+  it("accepts params.ids when outcomeIds is omitted and strips it from sidecar params", async () => {
+    const capturedArgs: unknown[][] = [];
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = makeClientWithWs(capturedArgs);
+
+    await client.watchOrderBooks(undefined, undefined, { ids: ["outcome-1"], foo: "bar" });
+
+    expect(warn).toHaveBeenCalledWith("Parameter 'ids' is deprecated, use 'outcomeIds' instead.");
+    expect(capturedArgs[0]).toEqual([["outcome-1"], undefined, { foo: "bar" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds TypeScript SDK compatibility for deprecated `ids` input on `watchOrderBooks`, matching Python's backwards-compatible behavior.
- Strips `params.ids` before forwarding sidecar params so the alias does not leak to the server.
- Adds focused Jest coverage for both compatibility forms.

Fixes #1283

## Test Plan
- `npm test -- --runTestsByPath tests/watch-order-books-compat.test.ts` *(blocked: generated TypeScript client artifacts are absent in this checkout; `pmxt/client.ts` cannot resolve `../generated/src/index.js`)*
- `npm run generate:sdk:typescript --workspace=pmxt-core` *(blocked: environment is missing `java`, required by openapi-generator-cli)*
- `git diff --check` *(pass)*
