### PR TITLE
fix(ts-sdk): raise hosted embedded errors

### DIFF
--- a/sdks/typescript/pmxt/hosted-routing.ts
+++ b/sdks/typescript/pmxt/hosted-routing.ts
@@ -156,11 +156,21 @@ export async function _tradingRequest(
         body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
     });
 
+    const text = await resp.text();
+
     if (!resp.ok) {
-        await raiseFromResponse(resp);
+        await raiseFromResponse(new Response(text, { status: resp.status, statusText: resp.statusText }));
     }
 
-    const text = await resp.text();
     if (!text) return null;
-    return JSON.parse(text);
+    const payload = JSON.parse(text);
+    if (
+        payload != null &&
+        typeof payload === "object" &&
+        ((payload as Record<string, unknown>).success === false ||
+            typeof (payload as Record<string, unknown>).error === "string")
+    ) {
+        await raiseFromResponse(new Response(text, { status: resp.status, statusText: resp.statusText }));
+    }
+    return payload;
 }

--- a/sdks/typescript/tests/hosted-routing-embedded-error.test.ts
+++ b/sdks/typescript/tests/hosted-routing-embedded-error.test.ts
@@ -1,0 +1,34 @@
+import { _tradingRequest } from "../pmxt/hosted-routing";
+import { HostedTradingError } from "../pmxt/hosted-errors";
+
+const client = { pmxtApiKey: "test_pmxt_key", exchangeName: "polymarket" };
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function installFetchResponse(payload: unknown, status = 200): jest.SpyInstance {
+  return jest.spyOn(global, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+describe("_tradingRequest embedded error envelopes", () => {
+  it("raises a hosted error for 2xx responses with success=false", async () => {
+    installFetchResponse({ success: false, error: "upstream rejected order" }, 200);
+
+    try {
+      await _tradingRequest(client, { method: "GET", path: "/v0/user/me/balances" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(HostedTradingError);
+      expect((err as HostedTradingError).status).toBe(200);
+      expect((err as HostedTradingError).detail).toBe("upstream rejected order");
+      return;
+    }
+
+    throw new Error("expected _tradingRequest to raise HostedTradingError");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix TypeScript hosted `_tradingRequest` to inspect 2xx JSON envelopes for `{ success: false }` / `{ error: ... }`
- Re-raise those embedded failures through the hosted error mapper so TS matches Python behavior
- Add a focused regression test for 2xx embedded hosted errors

Fixes #1304

## Test Plan
- `npm test --workspace=pmxtjs -- --runTestsByPath tests/hosted-routing-embedded-error.test.ts --runInBand` (RED before fix, PASS after fix)
- `npm test --workspace=pmxtjs -- --runTestsByPath tests/hosted-routing-embedded-error.test.ts tests/hosted-error-mapping.test.ts --runInBand`
- `git diff --check`

## Known local environment blockers
- `npm test --workspace=pmxtjs -- --runTestsByPath tests/hosted-dispatch.test.ts --runInBand` and `npm run build --workspace=pmxtjs` are blocked in this focused checkout because `sdks/typescript/generated/src/index.js` is absent; no generated SDK stubs were committed.
