### PR TITLE
fix(ts-sdk): require wallet for hosted build orders

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -2587,7 +2587,7 @@ export abstract class Exchange {
         if (extra["slippage_pct"] !== undefined) {
             body["slippage_pct"] = extra["slippage_pct"];
         }
-        if (this.walletAddress) body["user_address"] = this.walletAddress;
+        body["user_address"] = resolveWalletAddress(this);
         return body;
     }
 

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -219,6 +219,20 @@ function buildResponsePayload(side: "buy" | "sell" = "buy"): Record<string, unkn
 }
 
 describe("hosted write dispatch", () => {
+  it("buildOrder raises MissingWalletAddress locally when walletAddress is unset", async () => {
+    const spy = installFetchSpy(() => jsonResponse(buildResponsePayload("buy")));
+    const api = makePolymarket({ withWallet: false, withSigner: true });
+    await expect(api.buildOrder({
+      marketId: "11111111-1111-4111-8111-111111111111",
+      outcomeId: "22222222-2222-4222-8222-222222222222",
+      side: "buy",
+      type: "market",
+      amount: 5,
+      denom: "usdc",
+    } as any)).rejects.toBeInstanceOf(MissingWalletAddress);
+    expect(captured(spy)).toHaveLength(0);
+  });
+
   it("buildOrder → POST /v0/trade/build-order", async () => {
     const spy = installFetchSpy(() => jsonResponse(buildResponsePayload("buy")));
     const api = makePolymarket({ withSigner: true });


### PR DESCRIPTION
## Summary
- Make TypeScript hosted `buildOrder` require `walletAddress` at build time, matching Python's `_hosted_build_order_request` behavior.
- Add a hosted dispatch regression asserting `MissingWalletAddress` is raised locally with no network request.

Fixes #1286

## Test Plan
- `npm --workspace=pmxtjs test -- hosted-dispatch.test.ts --runInBand`

Note: the focused local test used an untracked generated-client stub because `sdks/typescript/generated/src/index.js` is absent in this checkout; no generated stub files were staged or committed.
