### PR TITLE
fix(sdk): expose venue filters in fetch params

### DIFF
--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -746,6 +746,8 @@ class MarketFetchParams(TypedDict, total=False):
     market_id: str
     outcome_id: str
     event_id: str
+    source_exchange: str
+    exchange: str
     category: str
     tags: List[str]
     filter: MarketFilterCriteria
@@ -764,6 +766,8 @@ class EventFetchParams(TypedDict, total=False):
     search_in: Literal["title", "description", "both"]
     event_id: str
     slug: str
+    source_exchange: str
+    exchange: str
     series: str
     category: str
     tags: List[str]

--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -450,6 +450,12 @@ export interface MarketFilterParams {
     /** Find markets belonging to an event */
     eventId?: string;
 
+    /** Filter by source venue (e.g. 'polymarket', 'kalshi', 'myriad'). */
+    sourceExchange?: string;
+
+    /** Alias for `sourceExchange`. */
+    exchange?: string;
+
     /** Pagination page (used by Limitless) */
     page?: number;
 
@@ -496,6 +502,12 @@ export interface EventFetchParams {
 
     /** Lookup by event slug */
     slug?: string;
+
+    /** Filter by source venue (e.g. 'polymarket', 'kalshi', 'myriad'). */
+    sourceExchange?: string;
+
+    /** Alias for `sourceExchange`. */
+    exchange?: string;
 
     /** Filter events by their parent series. Accepts the venue-native series id / ticker / slug. */
     series?: string;


### PR DESCRIPTION
## Summary
- Adds `sourceExchange` / `exchange` venue filter aliases to TypeScript market/event fetch parameter interfaces.
- Adds matching `source_exchange` / `exchange` TypedDict keys to Python market/event fetch parameter types.

Fixes #1317
Fixes #1318

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/models.py`
- `git diff --check`

Note: TypeScript compiler validation was attempted, but this cron host could not install workspace dependencies because `npm install` failed with `ENOSPC: no space left on device`. The change is type-only and mirrors the already-present core `BaseExchange` fetch parameter fields.
