### PR TITLE
Fix Smarkets resolutionDate fallback

### DIFF
--- a/core/src/exchanges/smarkets/normalizer.ts
+++ b/core/src/exchanges/smarkets/normalizer.ts
@@ -68,6 +68,14 @@ function buildContractOutcome(
     };
 }
 
+function parseSmarketsResolutionDate(event: SmarketsRawEvent): Date | undefined {
+    // Smarkets list and detail endpoints currently return end_date as null for
+    // many events. start_datetime is an event start, not a market resolution,
+    // so leave the unified resolution date unset instead of using a misleading
+    // fallback that can corrupt cross-venue ordering.
+    return event.end_date ? new Date(event.end_date) : undefined;
+}
+
 // ----------------------------------------------------------------------------
 // Normalizer
 // ----------------------------------------------------------------------------
@@ -117,12 +125,7 @@ export class SmarketsNormalizer implements IExchangeNormalizer<SmarketsRawEventW
             }
         }
 
-        // Derive resolution date from event end_date or start_datetime
-        const resolutionDate = event.end_date
-            ? new Date(event.end_date)
-            : event.start_datetime
-                ? new Date(event.start_datetime)
-                : new Date();
+        const resolutionDate = parseSmarketsResolutionDate(event);
 
         const um = {
             marketId: market.id,

--- a/core/test/normalizers/exchange-normalizers-2.test.ts
+++ b/core/test/normalizers/exchange-normalizers-2.test.ts
@@ -215,6 +215,36 @@ describe('SmarketsNormalizer', () => {
             expect(result.resolutionDate.getFullYear()).toBe(2025);
         });
 
+        it('does not use start_datetime as a fallback resolutionDate when end_date is missing', () => {
+            const rawEventWithoutEndDate: SmarketsRawEvent = {
+                ...rawEvent,
+                end_date: null,
+                start_datetime: '2025-05-01T09:00:00Z',
+            };
+            const raw = {
+                ...rawEventWithMarkets,
+                event: rawEventWithoutEndDate,
+            };
+
+            const result = normalizer.normalizeMarket(raw)!;
+            expect(result.resolutionDate).toBeUndefined();
+        });
+
+        it('does not default resolutionDate to the current time when Smarkets provides no dates', () => {
+            const rawEventWithoutDates: SmarketsRawEvent = {
+                ...rawEvent,
+                end_date: null,
+                start_datetime: null,
+            };
+            const raw = {
+                ...rawEventWithMarkets,
+                event: rawEventWithoutDates,
+            };
+
+            const result = normalizer.normalizeMarket(raw)!;
+            expect(result.resolutionDate).toBeUndefined();
+        });
+
         it('extracts category from event type string', () => {
             const result = normalizer.normalizeMarket(rawEventWithMarkets)!;
             expect(result.category).toBe('politics');


### PR DESCRIPTION
## Summary

- stop using `start_datetime` as a Smarkets `resolutionDate` fallback when `end_date` is missing
- stop defaulting missing Smarkets resolution dates to the current time
- add regression coverage for both missing-`end_date` paths

## Context

I checked the Smarkets public events endpoint and the single-event endpoint while looking at #1366. Both can return `end_date: null`; for example, `GET https://api.smarkets.com/v3/events/?limit=3&state=upcoming` and `GET /v3/events/{id}/` returned null `end_date` values for sampled events.

Since `start_datetime` is the event start time rather than a resolution time, exposing it as `resolutionDate` can make cross-venue sorting/filtering look more precise than the venue data supports. `UnifiedMarket.resolutionDate` is optional, so this now leaves it unset unless Smarkets actually provides `end_date`.

## Tests

- `npm test --workspace=pmxt-core -- --runTestsByPath test/normalizers/exchange-normalizers-2.test.ts`
- `npm run build --workspace=pmxt-core`
