### PR TITLE
fix(ts-sdk): forward apiSecret credentials

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -232,6 +232,9 @@ export interface ExchangeOptions {
     /** Venue-specific API key (e.g. Polymarket CLOB key). Optional. */
     apiKey?: string;
 
+    /** Venue-specific API secret for HMAC/CLOB-authenticated exchanges. Optional. */
+    apiSecret?: string;
+
     /** Venue-specific private key. Optional. */
     privateKey?: string;
 
@@ -320,6 +323,7 @@ export abstract class Exchange {
     public exchangeName: string;
     public pmxtApiKey?: string;
     protected apiKey?: string;
+    protected apiSecret?: string;
     protected privateKey?: string;
     protected proxyAddress?: string;
     protected signatureType?: number;
@@ -357,6 +361,7 @@ export abstract class Exchange {
     constructor(exchangeName: string, options: ExchangeOptions = {}) {
         this.exchangeName = exchangeName.toLowerCase();
         this.apiKey = options.apiKey;
+        this.apiSecret = options.apiSecret;
         this.privateKey = options.privateKey;
         this.proxyAddress = options.proxyAddress;
         this.signatureType = options.signatureType;
@@ -462,11 +467,12 @@ export abstract class Exchange {
     }
 
     protected getCredentials(): ExchangeCredentials | undefined {
-        if (!this.apiKey && !this.privateKey) {
+        if (!this.apiKey && !this.apiSecret && !this.privateKey) {
             return undefined;
         }
         return {
             apiKey: this.apiKey,
+            apiSecret: this.apiSecret,
             privateKey: this.privateKey,
             funderAddress: this.proxyAddress,
             signatureType: this.signatureType,

--- a/sdks/typescript/tests/exchange-credentials.test.ts
+++ b/sdks/typescript/tests/exchange-credentials.test.ts
@@ -1,0 +1,26 @@
+import { Exchange, ExchangeOptions } from "../pmxt/client";
+
+class TestExchange extends Exchange {
+  public exposedCredentials() {
+    return this.getCredentials();
+  }
+}
+
+describe("exchange credentials", () => {
+  it("accepts and forwards apiSecret with sidecar credentials", () => {
+    const options = {
+      apiKey: "api-key",
+      apiSecret: "api-secret",
+      privateKey: "private-key",
+      autoStartServer: false,
+    } satisfies ExchangeOptions;
+
+    const exchange = new TestExchange("polymarket", options);
+
+    expect(exchange.exposedCredentials()).toMatchObject({
+      apiKey: "api-key",
+      apiSecret: "api-secret",
+      privateKey: "private-key",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `apiSecret` to TypeScript `ExchangeOptions` and stores it on `Exchange`.
- Forwards `apiSecret` in sidecar credentials so Polymarket, Limitless, Probable, and GeminiTitan can receive the secret expected by core.
- Adds a focused regression test covering type acceptance and credentials forwarding.

Fixes #1371

## Test Plan
- `npm test -- --runTestsByPath tests/exchange-credentials.test.ts --runInBand`
- `npm test -- --runTestsByPath tests/sidecar-order-param-forwarding.test.ts tests/hosted-order-params-types.test.ts tests/exchange-credentials.test.ts --runInBand`
- `npx tsc --noEmit`

Note: local TypeScript SDK tests/build needed an untracked minimal `sdks/typescript/generated/src/index.ts` stub because generated SDK artifacts are absent in this focused checkout; the stub was not staged or committed.
