### PR TITLE
fix(python-sdk): accept wallet address in Hunch client

### DIFF
--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -551,6 +551,7 @@ class Hunch(Exchange):
         base_url: Optional[str] = None,
         auto_start_server: Optional[bool] = None,
         pmxt_api_key: Optional[str] = None,
+        wallet_address: Optional[str] = None,
     ) -> None:
         """
         Initialize Hunch client.
@@ -560,6 +561,7 @@ class Hunch(Exchange):
             base_url: Base URL of the PMXT sidecar server
             auto_start_server: Automatically start server if not running (default: True)
             pmxt_api_key: Hosted PMXT API key (optional; enables hosted mode)
+            wallet_address: EVM wallet address used for hosted reads/writes
         """
         super().__init__(
             exchange_name="hunch",
@@ -567,6 +569,7 @@ class Hunch(Exchange):
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,
+            wallet_address=wallet_address,
         )
 
 

--- a/sdks/python/tests/test_hosted_dispatch.py
+++ b/sdks/python/tests/test_hosted_dispatch.py
@@ -22,7 +22,7 @@ import pytest
 
 from pmxt._hosted_routing import HOSTED_TRADING_BASE_URL
 from pmxt._hosted_errors import MissingWalletAddress, NotSupported
-from pmxt._exchanges import Limitless, Polymarket
+from pmxt._exchanges import Hunch, Limitless, Polymarket
 from pmxt.errors import InvalidSignature
 import pmxt.client as client_module
 from pmxt.models import BuiltOrder
@@ -144,6 +144,17 @@ def _make_limitless(
     if with_signer:
         kwargs["signer"] = _MockSigner()
     return Limitless(**kwargs)
+
+
+def test_hunch_constructor_accepts_wallet_address_for_hosted_mode():
+    api = Hunch(
+        pmxt_api_key=PMXT_API_KEY,
+        wallet_address=WALLET_ADDRESS,
+        auto_start_server=False,
+    )
+
+    assert api.exchange_name == "hunch"
+    assert api.wallet_address == WALLET_ADDRESS
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Add `wallet_address` to the Python `Hunch` convenience client constructor.
- Forward the value to the shared `Exchange` base class so hosted-mode reads/writes can resolve wallet-scoped endpoints.
- Add a regression covering the Hunch constructor.

Fixes #1372

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/_exchanges.py sdks/python/tests/test_hosted_dispatch.py`
- `PYTHONPATH=/tmp/pmxt-pystub:sdks/python python3 -m pytest sdks/python/tests/test_hosted_dispatch.py::test_hunch_constructor_accepts_wallet_address_for_hosted_mode -q`

Note: the local checkout lacks committed generated `pmxt_internal` artifacts, so the focused pytest used an untracked `/tmp/pmxt-pystub` generated-client stub only for importability.