### PR TITLE
fix(ts-sdk): make hosted errors catchable by base class

### DIFF
--- a/sdks/typescript/pmxt/hosted-errors.ts
+++ b/sdks/typescript/pmxt/hosted-errors.ts
@@ -5,9 +5,9 @@
  * does not support multiple inheritance, so each hosted error class extends
  * the semantically-closest legacy parent (e.g. `InsufficientEscrowBalance`
  * extends `InsufficientFunds`) so existing `instanceof` checks continue to
- * match. The `static isHostedError = true` flag and the {@link isHostedError}
- * helper provide a structural alternative for callers that want to detect
- * hosted-mode failures regardless of the concrete subclass.
+ * match. `HostedTradingError[Symbol.hasInstance]` uses the `static
+ * isHostedError = true` flag so callers can also catch any hosted-mode failure
+ * with `e instanceof HostedTradingError`.
  */
 
 import {
@@ -24,6 +24,14 @@ export class HostedTradingError extends PmxtError {
     static readonly isHostedError = true;
     readonly status: number;
     readonly detail: string;
+
+    static [Symbol.hasInstance](value: unknown): boolean {
+        if (this !== HostedTradingError) {
+            return Function.prototype[Symbol.hasInstance].call(this, value);
+        }
+        const ctor = (value as { constructor?: { isHostedError?: boolean } } | null)?.constructor;
+        return ctor != null && ctor.isHostedError === true;
+    }
 
     constructor(status: number, detail: string) {
         super(detail);

--- a/sdks/typescript/tests/hosted-error-mapping.test.ts
+++ b/sdks/typescript/tests/hosted-error-mapping.test.ts
@@ -114,6 +114,20 @@ describe("isHostedError flag", () => {
     expect(isHostedError(err)).toBe(true);
   });
 
+  it.each([
+    ["HostedTradingError", new HostedTradingError(500, "x")],
+    ["InvalidApiKey", new InvalidApiKey(401, "x")],
+    ["InsufficientEscrowBalance", new InsufficientEscrowBalance(403, "x")],
+    ["OrderSizeTooSmall", new OrderSizeTooSmall(422, "x")],
+    ["OutcomeNotFound", new OutcomeNotFound(404, "x")],
+    ["CatalogUnavailable", new CatalogUnavailable(503, "x")],
+    ["BuiltOrderExpired", new BuiltOrderExpired(410, "x")],
+    ["InvalidSignature", new InvalidSignature(422, "x")],
+    ["NoLiquidity", new NoLiquidity(422, "x")],
+  ])("%s is catchable as HostedTradingError", (_label, err) => {
+    expect(err).toBeInstanceOf(HostedTradingError);
+  });
+
   it("MissingWalletAddress is NOT a hosted error (local-only)", () => {
     expect(isHostedError(new MissingWalletAddress("x"))).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Fixes TypeScript SDK hosted error detection so concrete hosted subclasses satisfy `instanceof HostedTradingError`.
- Keeps existing semantic parent classes (`InvalidApiKey` as `AuthenticationError`, `InsufficientEscrowBalance` as `InsufficientFunds`, etc.) while making the hosted base catch work via `Symbol.hasInstance` and the existing `isHostedError` marker.

Fixes #1411

## Test Plan
- `npm install`
- `npm test --workspace=pmxtjs -- hosted-error-mapping.test.ts --runInBand`
- `git diff --check`

## Notes
- `npm run build --workspace=pmxtjs` is blocked in this checkout by missing generated TypeScript SDK artifacts: `../generated/src/index.js` imported by `pmxt/client.ts` and `pmxt/server-manager.ts`.
