### PR TITLE
fix(sdks): align order book field types

### DIFF
--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -310,6 +310,9 @@ class OrderLevel:
     size: float
     """Number of contracts"""
 
+    order_count: Optional[int] = None
+    """Number of orders aggregated at this price level, when reported by the venue."""
+
 
 @dataclass
 class OrderBook:
@@ -326,6 +329,15 @@ class OrderBook:
 
     datetime: Optional[str] = None
     """ISO 8601 datetime string (CCXT-compatible)"""
+
+    is_neg_risk: Optional[bool] = None
+    """Whether the underlying market uses negative-risk collateral/netting semantics."""
+
+    last_trade_price: Optional[float] = None
+    """Last traded price for the outcome, when reported alongside the book."""
+
+    source_metadata: Optional[Dict[str, Any]] = None
+    """Raw venue-specific fields not promoted to first-class columns."""
 
 
 @dataclass

--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -149,6 +149,9 @@ export interface OrderLevel {
 
     /** Number of contracts */
     size: number;
+
+    /** Number of orders aggregated at this price level, when reported by the venue. */
+    orderCount?: number;
 }
 
 /**
@@ -166,6 +169,15 @@ export interface OrderBook {
 
     /** ISO 8601 datetime string of the snapshot (CCXT-compatible) */
     datetime?: string;
+
+    /** Whether the underlying market uses negative-risk collateral/netting semantics. */
+    isNegRisk?: boolean;
+
+    /** Last traded price for the outcome, when reported alongside the book. */
+    lastTradePrice?: number;
+
+    /** Raw venue-specific fields not promoted to first-class columns. */
+    sourceMetadata?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `orderCount` to TypeScript `OrderLevel` and `order_count` to Python `OrderLevel`.
- Add `isNegRisk`, `lastTradePrice`, and `sourceMetadata` to TypeScript `OrderBook`.
- Add `is_neg_risk`, `last_trade_price`, and `source_metadata` to Python `OrderBook`.

Fixes #1392
Fixes #1393
Fixes #1394
Fixes #1395

## Test Plan
- `python3 -m py_compile sdks/python/pmxt/models.py sdks/python/pmxt/client.py`
- `git diff --check`

Note: local TypeScript compiler validation was blocked in this fresh worktree because `node_modules/.bin/tsc` is not installed; GitHub generated-sync/CodeQL checks will validate the committed TypeScript surface.
