### PR TITLE
fix(typescript): make Position fields nullable to match core

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -349,19 +349,19 @@ export interface Position {
     outcomeId: string;
 
     /** Outcome label (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    outcomeLabel?: string;
+    outcomeLabel?: string | null;  // ✅ Added | null
 
     /** Position size (positive for long, negative for short) */
     size: number;
 
     /** Average entry price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    entryPrice?: number;
+    entryPrice?: number | null;    // ✅ Added | null
 
     /** Current market price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    currentPrice?: number;
+    currentPrice?: number | null;  // ✅ Added | null
 
     /** Unrealized profit/loss (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    unrealizedPnL?: number;
+    unrealizedPnL?: number | null; // ✅ Added | null
 
     /** Realized profit/loss */
     realizedPnL?: number;

--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -349,19 +349,19 @@ export interface Position {
     outcomeId: string;
 
     /** Outcome label (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    outcomeLabel?: string | null; 
+    outcomeLabel?: string | null;
 
     /** Position size (positive for long, negative for short) */
     size: number;
 
     /** Average entry price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    entryPrice?: number | null;  
+    entryPrice?: number | null;
 
     /** Current market price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    currentPrice?: number | null; 
+    currentPrice?: number | null;
 
     /** Unrealized profit/loss (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    unrealizedPnL?: number | null; 
+    unrealizedPnL?: number | null;
 
     /** Realized profit/loss */
     realizedPnL?: number;

--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -349,19 +349,19 @@ export interface Position {
     outcomeId: string;
 
     /** Outcome label (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    outcomeLabel?: string | null;  // ✅ Added | null
+    outcomeLabel?: string | null; 
 
     /** Position size (positive for long, negative for short) */
     size: number;
 
     /** Average entry price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    entryPrice?: number | null;    // ✅ Added | null
+    entryPrice?: number | null;  
 
     /** Current market price (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    currentPrice?: number | null;  // ✅ Added | null
+    currentPrice?: number | null; 
 
     /** Unrealized profit/loss (populated in venue-direct mode; may be undefined in hosted mode when the server hasn't enriched). */
-    unrealizedPnL?: number | null; // ✅ Added | null
+    unrealizedPnL?: number | null; 
 
     /** Realized profit/loss */
     realizedPnL?: number;


### PR DESCRIPTION
## What this PR does

Fixes TypeScript Position interface to match core and Python SDK.

### The Problem
Four Position fields are typed as `string` / `number` but the hosted API returns `null`:
- `outcomeLabel`
- `entryPrice`
- `currentPrice`
- `unrealizedPnL`

### The Fix
Added `| null` to all four fields.

### Why it matters
TypeScript users will now get proper type warnings when handling nullable fields.

Fixes #1405