### PR TITLE
fix(python-sdk): route Myriad wallet address correctly

### DIFF
--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -284,7 +284,7 @@ class Myriad(Exchange):
         super().__init__(
             exchange_name="myriad",
             api_key=api_key,
-            private_key=wallet_address,
+            wallet_address=wallet_address,
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,

--- a/sdks/python/tests/test_hosted_dispatch.py
+++ b/sdks/python/tests/test_hosted_dispatch.py
@@ -22,7 +22,7 @@ import pytest
 
 from pmxt._hosted_routing import HOSTED_TRADING_BASE_URL
 from pmxt._hosted_errors import MissingWalletAddress, NotSupported
-from pmxt._exchanges import Hunch, Limitless, Polymarket
+from pmxt._exchanges import Hunch, Limitless, Myriad, Polymarket
 from pmxt.errors import InvalidSignature
 import pmxt.client as client_module
 from pmxt.models import BuiltOrder
@@ -110,6 +110,17 @@ def _install_signing_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(client_module, "validate_typed_data", _noop_validate)
     monkeypatch.setattr(client_module, "validate_economics", _noop_validate)
     monkeypatch.setattr(client_module, "verify_signature", _noop_verify)
+
+
+def test_myriad_wallet_address_populates_wallet_slot_not_private_key() -> None:
+    client = Myriad(
+        wallet_address=WALLET_ADDRESS,
+        pmxt_api_key=PMXT_API_KEY,
+        auto_start_server=False,
+    )
+
+    assert client.wallet_address == WALLET_ADDRESS
+    assert client.private_key is None
 
 
 def _make_polymarket(


### PR DESCRIPTION
## Summary
- Fixes `Myriad(wallet_address=...)` in the Python SDK so the address populates the base `wallet_address` slot instead of `private_key`.
- Adds a regression test proving the public wallet address no longer triggers private-key signer setup or leaves `wallet_address` unset.

Fixes #1448

## Test Plan
- `uv run --with pytest --with httpx pytest sdks/python/tests/test_hosted_dispatch.py::test_myriad_wallet_address_populates_wallet_slot_not_private_key -q`
- `uv run --with pytest --with httpx pytest sdks/python/tests/test_hosted_dispatch.py -q`

Note: local checkout lacks committed generated `pmxt_internal` artifacts, so I used an untracked temporary generated-client stub only for local test importability and removed it before staging.