### PR TITLE
fix(typescript): export public SDK option types

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -27,9 +27,11 @@ import * as models from "./pmxt/models.js";
 import * as errors from "./pmxt/errors.js";
 
 export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Suibets, Rain, Hunch, Mock, PolymarketOptions } from "./pmxt/client.js";
+export type { SuiBetsOptions } from "./pmxt/client.js";
 export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
 export { Router } from "./pmxt/router.js";
+export type { RouterOptions } from "./pmxt/router.js";
 export { ServerManager } from "./pmxt/server-manager.js";
 export {
     HOSTED_URL,


### PR DESCRIPTION
## Summary
- Re-export `SuiBetsOptions` from the TypeScript package root so consumers can import the public SuiBets constructor options type directly.
- Re-export `RouterOptions` from the TypeScript package root to match the existing Python package-root export.

Fixes #1445
Fixes #1380

## Test Plan
- `git diff --check`
- Node static assertion that `sdks/typescript/index.ts` contains both public type exports
- `tsc` could not be run locally because this checkout has no `node_modules/.bin/tsc`; this PR only changes package-root type export statements and GitHub generated-sync checks will validate committed generated surfaces.
