### PR TITLE
fix(typescript): add documented event helper methods

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -867,6 +867,58 @@ export abstract class Exchange {
     }
 
     /**
+     * Pre-warm the sidecar's internal caches for a market outcome.
+     *
+     * @param outcomeId - The CLOB token ID for the outcome.
+     */
+    async preWarmMarket(outcomeId: string): Promise<void> {
+        await this.initPromise;
+        try {
+            const json = await this.sidecarPostRequest("preWarmMarket", [outcomeId]);
+            this.handleResponse(json);
+        } catch (error) {
+            if (error instanceof PmxtError) throw error;
+            throw new PmxtError(`Failed to preWarmMarket: ${error}`);
+        }
+    }
+
+    /**
+     * Fetch a single Probable event by its numeric ID.
+     *
+     * @param id - The numeric event ID.
+     * @returns The event, or null when the venue has no matching event.
+     */
+    async getEventById(id: string): Promise<UnifiedEvent | null> {
+        await this.initPromise;
+        try {
+            const json = await this.sidecarPostRequest("getEventById", [id]);
+            const data = this.handleResponse(json);
+            return data == null ? null : convertEvent(data);
+        } catch (error) {
+            if (error instanceof PmxtError) throw error;
+            throw new PmxtError(`Failed to getEventById: ${error}`);
+        }
+    }
+
+    /**
+     * Fetch a single Probable event by its URL slug.
+     *
+     * @param slug - The event slug.
+     * @returns The event, or null when the venue has no matching event.
+     */
+    async getEventBySlug(slug: string): Promise<UnifiedEvent | null> {
+        await this.initPromise;
+        try {
+            const json = await this.sidecarPostRequest("getEventBySlug", [slug]);
+            const data = this.handleResponse(json);
+            return data == null ? null : convertEvent(data);
+        } catch (error) {
+            if (error instanceof PmxtError) throw error;
+            throw new PmxtError(`Failed to getEventBySlug: ${error}`);
+        }
+    }
+
+    /**
      * Read a hosted catalog endpoint directly.
      *
      * Hosted-only Router APIs such as matched clusters are not part of the

--- a/sdks/typescript/tests/event-methods.test.ts
+++ b/sdks/typescript/tests/event-methods.test.ts
@@ -1,0 +1,78 @@
+import { Polymarket, Probable } from "../pmxt/client";
+
+interface CapturedFetch {
+  url: string;
+  init?: RequestInit;
+}
+
+function installFetchSpy(handler: (req: CapturedFetch) => Response): jest.SpyInstance {
+  const captured: CapturedFetch[] = [];
+  const spy = jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as URL | Request).toString();
+    const rec: CapturedFetch = { url, init };
+    captured.push(rec);
+    return handler(rec);
+  });
+  (spy as unknown as { captured: CapturedFetch[] }).captured = captured;
+  return spy;
+}
+
+function captured(spy: jest.SpyInstance): CapturedFetch[] {
+  return (spy as unknown as { captured: CapturedFetch[] }).captured;
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("event-specific SDK methods", () => {
+  it("preWarmMarket dispatches the documented sidecar method", async () => {
+    const spy = installFetchSpy(() => jsonResponse({ success: true, data: null }));
+    const api = new Polymarket({ baseUrl: "http://sidecar.test", autoStartServer: false });
+
+    await api.preWarmMarket("12345");
+
+    const reqs = captured(spy);
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].url).toBe("http://sidecar.test/api/polymarket/preWarmMarket");
+    expect(reqs[0].init?.method).toBe("POST");
+    expect(JSON.parse(reqs[0].init?.body as string)).toEqual({
+      args: ["12345"],
+    });
+  });
+
+  it("getEventById returns null without conversion when sidecar returns null", async () => {
+    installFetchSpy(() => jsonResponse({ success: true, data: null }));
+    const api = new Probable({ baseUrl: "http://sidecar.test", autoStartServer: false });
+
+    await expect(api.getEventById("180")).resolves.toBeNull();
+  });
+
+  it("getEventBySlug converts returned event markets", async () => {
+    const spy = installFetchSpy(() => jsonResponse({
+      success: true,
+      data: {
+        id: "180",
+        title: "Example event",
+        markets: [
+          { id: "m1", title: "Will it happen?", outcomes: [] },
+        ],
+      },
+    }));
+    const api = new Probable({ baseUrl: "http://sidecar.test", autoStartServer: false });
+
+    const event = await api.getEventBySlug("example-event");
+
+    expect(event?.title).toBe("Example event");
+    expect(event?.markets).toHaveLength(1);
+    expect(captured(spy)[0].url).toBe("http://sidecar.test/api/probable/getEventBySlug");
+    expect(JSON.parse(captured(spy)[0].init?.body as string).args).toEqual(["example-event"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the documented TypeScript SDK `Exchange` methods `preWarmMarket`, `getEventById`, and `getEventBySlug`.
- Routes the methods through the sidecar method namespace, matching the existing Python SDK behavior.
- Adds focused Jest coverage for dispatch, null return handling, and event conversion.

Fixes #1491

## Test Plan
- `git diff --cached --check` before commit
- `npm test --workspace=pmxtjs -- event-methods.test.ts --runInBand` was attempted but the checkout has no installed Node dependencies and `npm install --workspaces --include-workspace-root` timed out after 300s in this cron environment before producing `node_modules`; no test results are claimed from Jest.
