### PR TITLE
fix(typescript): export ExchangeOptions from package root

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -27,7 +27,7 @@ import * as models from "./pmxt/models.js";
 import * as errors from "./pmxt/errors.js";
 
 export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Suibets, Rain, Hunch, Mock, PolymarketOptions } from "./pmxt/client.js";
-export type { SuiBetsOptions } from "./pmxt/client.js";
+export type { ExchangeOptions, SuiBetsOptions } from "./pmxt/client.js";
 export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
 export { Router } from "./pmxt/router.js";


### PR DESCRIPTION
## Summary
- Export `ExchangeOptions` from the TypeScript package root alongside the existing client option types.

Fixes #1463

## Test Plan
- `git diff --check`
- `node -e "const fs=require('fs'); const s=fs.readFileSync('sdks/typescript/index.ts','utf8'); if(!s.includes('export type { ExchangeOptions, SuiBetsOptions }')) process.exit(1); console.log('ExchangeOptions root export present')"`

Note: this is a package-root type export only; no runtime code is changed.
