### PR TITLE
fix(python-sdk): type api_secret in exchange options

### DIFF
--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -656,6 +656,7 @@ class ExchangeOptions(TypedDict, total=False):
     base_url: str
     auto_start_server: bool
     api_key: str
+    api_secret: str
     private_key: str
     api_token: str
     proxy_address: str


### PR DESCRIPTION
## Summary
- Add `api_secret` to Python's shared `ExchangeOptions` TypedDict so it matches the TypeScript `ExchangeOptions.apiSecret` surface and the existing concrete Python exchange constructors.

Fixes #1501

## Test Plan
- `git diff --check`
- `python3 -m py_compile sdks/python/pmxt/models.py`
- `python3 - <<'PY' ... PY` AST check confirming `ExchangeOptions` declares `api_secret`
