### PR TITLE
fix(ts-sdk): export version constant

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -26,6 +26,8 @@ import { FeedClient } from "./pmxt/feed-client.js";
 import * as models from "./pmxt/models.js";
 import * as errors from "./pmxt/errors.js";
 
+export const __version__ = "2.17.1";
+
 export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, Baozi, Opinion, Metaculus, Smarkets, PolymarketUS, GeminiTitan, Hyperliquid, SuiBets, Suibets, Rain, Hunch, Mock, PolymarketOptions } from "./pmxt/client.js";
 export type { ExchangeOptions, SuiBetsOptions } from "./pmxt/client.js";
 export { FeedClient } from "./pmxt/feed-client.js";


### PR DESCRIPTION
## Summary
- Export a TypeScript `__version__` constant from the package root to match the Python SDK public module version surface.
- Keep the value aligned with the Python SDK's current `pmxt.__version__` value.

Fixes #1568

## Test Plan
- `git diff --check`
- `node` + TypeScript `transpileModule` syntax check for `sdks/typescript/index.ts`
- Attempted targeted `tsc` compile; blocked by missing committed generated client artifacts (`sdks/typescript/generated/src/index.js`), so no generated stubs were committed.
