### PR TITLE
fix(polymarket-us): prevent websocket connect hangs with garbage-collected timeout

### DIFF
--- a/core/src/exchanges/polymarket_us/websocket.ts
+++ b/core/src/exchanges/polymarket_us/websocket.ts
@@ -145,7 +145,24 @@ export class PolymarketUSWebSocket {
             socket.on('trade', (msg: SdkTrade) => this.handleTrade(msg));
             socket.on('error', (err: Error) => this.handleError(err));
             socket.on('close', () => this.handleClose());
-            await socket.connect();
+            // Wrap connection in a timeout with proper garbage collection
+            const CONNECTION_TIMEOUT_MS = 15000; // 15s is standard for trading API handshakes
+            let timeoutHandle: NodeJS.Timeout;
+            
+            const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(() => {
+                    reject(new Error(`PolymarketUS WebSocket connection timed out after ${CONNECTION_TIMEOUT_MS}ms`));
+                }, CONNECTION_TIMEOUT_MS);
+            });
+
+            try {
+                await Promise.race([
+                    socket.connect(),
+                    timeoutPromise
+                ]);
+            } finally {
+                clearTimeout(timeoutHandle!); // Always clear the timer so the event loop can breathe
+            }
             this.socket = socket;
         })();
 

--- a/core/src/exchanges/polymarket_us/websocket.ts
+++ b/core/src/exchanges/polymarket_us/websocket.ts
@@ -148,7 +148,7 @@ export class PolymarketUSWebSocket {
             // Wrap connection in a timeout with proper garbage collection
             const CONNECTION_TIMEOUT_MS = 15000; // 15s is standard for trading API handshakes
             let timeoutHandle: NodeJS.Timeout;
-            
+
             const timeoutPromise = new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {
                     reject(new Error(`PolymarketUS WebSocket connection timed out after ${CONNECTION_TIMEOUT_MS}ms`));


### PR DESCRIPTION
## Description
Fixes #722. 

The PolymarketUS WebSocket adapter lacked a connection timeout, meaning network partitions or unreachable endpoints during the TLS/TCP handshake would cause `socket.connect()` to hang indefinitely, blocking `watchOrderBook()` and `watchTrades()`.

This PR implements the requested timeout but wraps it in a `try/finally` block with `clearTimeout`. This ensures that successful connections immediately garbage-collect the timer, preventing dangling callbacks from polluting the Node.js event loop during high-frequency reconnects.