### PR TITLE
fix(limitless): throw on watchOrderBook failure instead of silent swallow

### DIFF
--- a/core/src/exchanges/limitless/websocket.ts
+++ b/core/src/exchanges/limitless/websocket.ts
@@ -193,8 +193,13 @@ export class LimitlessWebSocket {
 
             return await Promise.race([wsUpdatePromise, timeoutPromise]);
         } catch (err) {
-            // Fallback to empty orderbook if all else fails
-            return this.getEmptyOrderbook();
+            logger.error('LimitlessWS: watchOrderBook failed', { 
+                market: marketSlug, 
+                error: err instanceof Error ? err.message : String(err)
+            });
+            
+            // Do not return fake liquidity. Force the upstream loop to handle the break.
+            throw err; 
         }
     }
 

--- a/core/src/exchanges/limitless/websocket.ts
+++ b/core/src/exchanges/limitless/websocket.ts
@@ -193,13 +193,13 @@ export class LimitlessWebSocket {
 
             return await Promise.race([wsUpdatePromise, timeoutPromise]);
         } catch (err) {
-            logger.error('LimitlessWS: watchOrderBook failed', { 
-                market: marketSlug, 
+            logger.error('LimitlessWS: watchOrderBook failed', {
+                market: marketSlug,
                 error: err instanceof Error ? err.message : String(err)
             });
-            
+
             // Do not return fake liquidity. Force the upstream loop to handle the break.
-            throw err; 
+            throw err;
         }
     }
 


### PR DESCRIPTION
## Description
Fixes #676 and closes #1374.

The `watchOrderBook` method for Limitless was previously catching all SDK/network errors and silently returning an empty orderbook. This caused two severe issues:
1. Upstream stream loops (`streamSingle`) would spin infinitely at max CPU.
2. Downstream trading logic received false "zero liquidity" signals instead of feed degradation alerts.

This PR removes the empty fallback. It now properly logs the error (including the market context as requested in #1374) and throws it, forcing the caller to handle the failure and allowing circuit breakers / reconnect logic to function normally.