### PR TITLE
docs(suibets): remove deprecated events endpoint 

### DIFF
--- a/core/src/exchanges/suibets/api.ts
+++ b/core/src/exchanges/suibets/api.ts
@@ -11,7 +11,6 @@
  *   GET /api/p2p/offers          - List open P2P offers (status, matchId, sport, limit, offset)
  *   GET /api/p2p/offers/:id      - Get a single P2P offer by ID
  *   GET /api/p2p/my?wallet=...   - Get user activity (created offers, matched bets, parlays)
- *   GET /api/events/upcoming     - List upcoming sports events (sport, limit)
  */
 
 // No runtime exports — this file serves as API documentation only.


### PR DESCRIPTION
## Description
Fixes #1356.

Issue #1356 reported that the SuiBets `GET /api/events/upcoming` endpoint was returning a `400 Bad Request`. 

Upon auditing the runtime logic, I found that `fetchRawEvents` was already successfully refactored to synthesize events from `/api/p2p/offers` instead of using the broken endpoint. However, the legacy endpoint was left dangling in the `api.ts` documentation, leading to the open issue.

This PR simply removes the deprecated endpoint from the documentation to align it with the current implementation and safely closes the stale issue.