### PR TITLE
fix(suibets): model onchainState to restore accurate order book liquidity

### DIFF
--- a/core/src/exchanges/suibets/fetcher.ts
+++ b/core/src/exchanges/suibets/fetcher.ts
@@ -23,6 +23,12 @@ export interface SuibetsRawOffer {
     isOnchain?: boolean;
     onchainOfferId?: string;
     leagueName?: string;
+    onchainState?: {
+        makerRemaining?: string;
+        totalLiquidity?: string;
+        filledAmount?: string;
+        status?: string;
+    };
 }
 
 export interface SuibetsRawEvent {

--- a/core/src/exchanges/suibets/normalizer.ts
+++ b/core/src/exchanges/suibets/normalizer.ts
@@ -12,7 +12,8 @@ import {
 } from './utils';
 
 function liquidity(offer: SuibetsRawOffer): number {
-    const remaining = offer.remainingStake ?? offer.creatorStake;
+    // Prioritize live onchainState.makerRemaining data before falling back to legacy fields
+    const remaining = offer.onchainState?.makerRemaining ?? offer.remainingStake ?? offer.creatorStake;
     return mistToSui(remaining);
 }
 


### PR DESCRIPTION
## Description
Fixes #1354.

SuiBets updated their live API to nest critical liquidity data inside a new `onchainState` object. Because PMXT's `SuibetsRawOffer` interface did not model this nested object, the `makerRemaining` data was being silently dropped during normalization, resulting in inaccurate size calculations for the order book.

This PR:
1. Updates the `SuibetsRawOffer` interface to explicitly model the `onchainState` payload.
2. Threads `onchainState.makerRemaining` through `normalizer.ts` so order book levels now reflect true resting liquidity rather than placeholder zeroes.
3. Implements safe fallbacks to prevent `NaN` pollution if the object is missing.