### PR TITLE
fix(ts-sdk): make history params optional

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -1868,12 +1868,15 @@ export abstract class Exchange {
      */
     async fetchOHLCV(
         outcomeId: string | MarketOutcome,
-        params: any
+        params: any = {}
     ): Promise<PriceCandle[]> {
         await this.initPromise;
         const resolvedOutcomeId = resolveOutcomeId(outcomeId);
         try {
-            const paramsDict: any = { resolution: params.resolution };
+            const paramsDict: any = {};
+            if (params.resolution) {
+                paramsDict.resolution = params.resolution;
+            }
             if (params.start) {
                 paramsDict.start = params.start.toISOString();
             }
@@ -1906,7 +1909,7 @@ export abstract class Exchange {
      */
     async fetchTrades(
         outcomeId: string | MarketOutcome,
-        params: any
+        params: any = {}
     ): Promise<Trade[]> {
         await this.initPromise;
         const resolvedOutcomeId = resolveOutcomeId(outcomeId);

--- a/sdks/typescript/tests/history-optional-params.test.ts
+++ b/sdks/typescript/tests/history-optional-params.test.ts
@@ -1,0 +1,36 @@
+import { Polymarket } from "../pmxt/client";
+import { LOCAL_URL } from "../pmxt/constants";
+
+function makePolymarket(): Polymarket {
+  return new Polymarket({ autoStartServer: false, baseUrl: LOCAL_URL });
+}
+
+describe("optional history params", () => {
+  it("fetchOHLCV accepts only an outcome ID", async () => {
+    const api = makePolymarket();
+    const read = jest
+      .spyOn(api as any, "sidecarReadRequest")
+      .mockResolvedValue({ success: true, data: [] });
+
+    await expect(api.fetchOHLCV("outcome-1")).resolves.toEqual([]);
+    expect(read).toHaveBeenCalledWith(
+      "fetchOHLCV",
+      { outcomeId: "outcome-1" },
+      ["outcome-1", {}],
+    );
+  });
+
+  it("fetchTrades accepts only an outcome ID", async () => {
+    const api = makePolymarket();
+    const read = jest
+      .spyOn(api as any, "sidecarReadRequest")
+      .mockResolvedValue({ success: true, data: [] });
+
+    await expect(api.fetchTrades("outcome-1")).resolves.toEqual([]);
+    expect(read).toHaveBeenCalledWith(
+      "fetchTrades",
+      { outcomeId: "outcome-1" },
+      ["outcome-1", {}],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Make the TypeScript SDK's `fetchOHLCV` and `fetchTrades` history-filter argument optional, matching the Python SDK and preventing one-argument calls from dereferencing `undefined`.

`fetchOHLCV` now also omits an unset `resolution` from the sidecar query instead of serializing an undefined field.

Fixes #1556

## Test plan

- RED: `npm test --workspace=pmxtjs -- --runTestsByPath tests/history-optional-params.test.ts --runInBand` failed with TS2554 because both methods required a second argument.
- GREEN: the same target passed (2 tests).
- `npm test --workspace=pmxtjs -- --runInBand` (17 suites, 86 tests passed).
- `node sdks/typescript/scripts/generate-client-methods.js`
- `git diff --check`

The checkout does not contain committed generated TypeScript client artifacts, so local Jest used a temporary untracked `sdks/typescript/generated/src/index.ts` import stub. The stub was removed before staging and is not part of this PR.
