### PR TITLE
docs(sdks): align prefunded escrow comments

### DIFF
--- a/sdks/python/pmxt/constants.py
+++ b/sdks/python/pmxt/constants.py
@@ -76,10 +76,11 @@ def resolve_pmxt_base_url(
     return ResolvedBaseUrl(LOCAL_URL, None, False)
 
 
-#: Known PreFundedEscrow contract addresses on Polygon (chain 137).
+#: Known pre-funded PreFundedEscrow contract addresses on Polygon (chain 137).
 #:
 #: Hosted typed-data validation accepts these addresses as EIP-712
-#: ``verifyingContract`` values.
+#: ``verifyingContract`` values, allowing orders to use the shared escrow
+#: balance rather than a per-venue deposit.
 PREFUNDED_ESCROW_ADDRESSES: frozenset[str] = frozenset({
     "0x3ad326f78b1390b9a5dc5f00e7f62f8632de23e2",
 })

--- a/sdks/typescript/pmxt/constants.ts
+++ b/sdks/typescript/pmxt/constants.ts
@@ -67,9 +67,10 @@ export function resolvePmxtBaseUrl(args: {
 }
 
 /**
- * Lowercase 0x-prefixed escrow addresses that are pre-funded by pmxt for
- * hosted trading. Orders routed through these addresses use the shared
- * escrow balance rather than a per-venue deposit.
+ * Lowercase 0x-prefixed PreFundedEscrow addresses on Polygon (chain 137).
+ * Hosted typed-data validation accepts these addresses as EIP-712
+ * verifyingContract values, allowing orders to use the shared escrow balance
+ * rather than a per-venue deposit.
  */
 export const PREFUNDED_ESCROW_ADDRESSES: ReadonlySet<string> = new Set([
     "0x3ad326f78b1390b9a5dc5f00e7f62f8632de23e2",


### PR DESCRIPTION
## Summary

Align the Python and TypeScript comments for `PREFUNDED_ESCROW_ADDRESSES` so both SDKs document:

- Polygon / chain 137
- the EIP-712 `verifyingContract` role
- the shared escrow balance behavior

No runtime values or behavior change.

Fixes #1620

## Validation

- `python -m py_compile sdks/python/pmxt/constants.py`
- `git diff --check`