### PR TITLE
feat(python): add SuiBets wallet options

### DIFF
--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -75,6 +75,7 @@ from .models import (
     OrderHistoryParams,
     ExchangeOptions,
     PolymarketOptions,
+    SuiBetsOptions,
     RouterOptions,
     FeedClientOptions,
     MatchResult,
@@ -194,6 +195,7 @@ __all__ = [
     "FeedClient",
     "ExchangeOptions",
     "PolymarketOptions",
+    "SuiBetsOptions",
     "RouterOptions",
     "FeedClientOptions",
     # Environment

--- a/sdks/python/pmxt/_exchanges.py
+++ b/sdks/python/pmxt/_exchanges.py
@@ -500,6 +500,7 @@ class SuiBets(Exchange):
         base_url: Optional[str] = None,
         auto_start_server: Optional[bool] = None,
         pmxt_api_key: Optional[str] = None,
+        wallet_address: Optional[str] = None,
     ) -> None:
         """
         Initialize SuiBets client.
@@ -508,13 +509,21 @@ class SuiBets(Exchange):
             base_url: Base URL of the PMXT sidecar server
             auto_start_server: Automatically start server if not running (default: True)
             pmxt_api_key: Hosted PMXT API key (optional; enables hosted mode)
+            wallet_address: Sui wallet address used for hosted reads
         """
         super().__init__(
             exchange_name="suibets",
             base_url=base_url,
             auto_start_server=auto_start_server,
             pmxt_api_key=pmxt_api_key,
+            wallet_address=wallet_address,
         )
+
+    def _get_credentials_dict(self) -> Optional[Dict[str, Any]]:
+        creds = super()._get_credentials_dict() or {}
+        if self.wallet_address:
+            creds["walletAddress"] = self.wallet_address
+        return creds if creds else None
 
 
 class Rain(Exchange):

--- a/sdks/python/pmxt/models.py
+++ b/sdks/python/pmxt/models.py
@@ -668,6 +668,11 @@ class PolymarketOptions(ExchangeOptions, total=False):
     signature_type: Union[Literal["eoa", "poly-proxy", "gnosis-safe"], int]
 
 
+class SuiBetsOptions(ExchangeOptions, total=False):
+    """Constructor options for SuiBets clients."""
+    wallet_address: str
+
+
 class RouterOptions(TypedDict, total=False):
     """Constructor options for Router clients."""
     pmxt_api_key: str

--- a/sdks/python/tests/test_hosted_dispatch.py
+++ b/sdks/python/tests/test_hosted_dispatch.py
@@ -22,7 +22,7 @@ import pytest
 
 from pmxt._hosted_routing import HOSTED_TRADING_BASE_URL
 from pmxt._hosted_errors import MissingWalletAddress, NotSupported
-from pmxt._exchanges import Hunch, Limitless, Myriad, Polymarket
+from pmxt._exchanges import Hunch, Limitless, Myriad, Polymarket, SuiBets
 from pmxt.errors import InvalidSignature
 import pmxt.client as client_module
 from pmxt.models import BuiltOrder
@@ -166,6 +166,17 @@ def test_hunch_constructor_accepts_wallet_address_for_hosted_mode():
 
     assert api.exchange_name == "hunch"
     assert api.wallet_address == WALLET_ADDRESS
+
+
+def test_suibets_constructor_accepts_wallet_address_for_hosted_mode() -> None:
+    api = SuiBets(
+        pmxt_api_key="hosted-key",
+        wallet_address=WALLET_ADDRESS,
+        auto_start_server=False,
+    )
+
+    assert api.wallet_address == WALLET_ADDRESS
+    assert api._get_credentials_dict() == {"walletAddress": WALLET_ADDRESS}
 
 
 # --------------------------------------------------------------------------- #

--- a/sdks/python/tests/test_public_exports.py
+++ b/sdks/python/tests/test_public_exports.py
@@ -25,7 +25,7 @@ def test_websocket_return_types_are_public_exports():
                 if isinstance(item, ast.Constant) and isinstance(item.value, str)
             )
 
-    expected = {"FirehoseEvent", "SubscribedAddressSnapshot", "ExchangeOptions", "PolymarketOptions", "RouterOptions", "FeedClientOptions", "SeriesFetchParams", "TradesParams", "FetchOrderBookParams", "MatchedClusterSort", "FetchMatchedMarketClustersParams", "FetchMatchedEventClustersParams"}
+    expected = {"FirehoseEvent", "SubscribedAddressSnapshot", "ExchangeOptions", "PolymarketOptions", "SuiBetsOptions", "RouterOptions", "FeedClientOptions", "SeriesFetchParams", "TradesParams", "FetchOrderBookParams", "MatchedClusterSort", "FetchMatchedMarketClustersParams", "FetchMatchedEventClustersParams"}
     assert expected <= imported_models
     assert expected <= public_exports
 


### PR DESCRIPTION
## Summary

- add and publicly export a Python SuiBetsOptions type
- accept wallet_address in the Python SuiBets constructor
- forward the address as the sidecar walletAddress credential while retaining hosted-routing state
- cover both the public export and constructor/credential behavior

Closes #1651. Also resolves the current Python side of #734.

## Verification

- focused export and hosted-dispatch tests: 39 passed
- full Python SDK suite: 260 passed, 66 deselected
- touched Python compilation passed
- git diff --check passed