### PR TITLE
fix(limitless): wire unwatchOrderBook to WebSocket unsubscribe

### DIFF
--- a/core/src/exchanges/limitless/index.ts
+++ b/core/src/exchanges/limitless/index.ts
@@ -483,6 +483,12 @@ export class LimitlessExchange extends PredictionMarketExchange {
         return ws.watchOrderBook(slug);
     }
 
+    async unwatchOrderBook(outcomeId: string): Promise<void> {
+        const slug = await this.resolveSlug(outcomeId);
+        const ws = this.ensureWs();
+        await ws.unsubscribe(slug);
+    }
+
     async watchTrades(outcomeId: string, address?: string, since?: number, limit?: number): Promise<Trade[]> {
         const slug = await this.resolveSlug(outcomeId);
         const ws = this.ensureWs();

--- a/core/test/unit/limitless-unwatch-orderbook.core.test.ts
+++ b/core/test/unit/limitless-unwatch-orderbook.core.test.ts
@@ -1,0 +1,48 @@
+import { LimitlessExchange } from '../../src/exchanges/limitless';
+import type { OrderBook } from '../../src/types';
+
+/**
+ * Regression for #1660: LimitlessExchange never overrode `unwatchOrderBook`,
+ * so calling it always threw "unwatchOrderBook() is not supported by Limitless"
+ * even though `LimitlessWebSocket.unsubscribe()` already exists. The override
+ * must resolve the outcome slug (same as `watchOrderBook`) and forward it to
+ * the websocket's `unsubscribe()`.
+ */
+describe('LimitlessExchange.unwatchOrderBook', () => {
+    const SLUG = 'some-market-slug';
+
+    function makeExchangeWithFakeWs() {
+        const exchange = new LimitlessExchange();
+        const calls = { watch: [] as string[], unsubscribe: [] as string[] };
+        const emptyBook: OrderBook = { bids: [], asks: [] } as OrderBook;
+        const fakeWs = {
+            watchOrderBook: async (slug: string): Promise<OrderBook> => {
+                calls.watch.push(slug);
+                return emptyBook;
+            },
+            unsubscribe: async (slug: string): Promise<void> => {
+                calls.unsubscribe.push(slug);
+            },
+        };
+        // Inject the fake websocket so ensureWs() returns it without opening a
+        // real connection. A non-numeric outcome id is treated as a slug by
+        // resolveSlug(), so no network lookup happens.
+        (exchange as any).ws = fakeWs;
+        return { exchange, calls };
+    }
+
+    test('forwards the resolved slug to LimitlessWebSocket.unsubscribe()', async () => {
+        const { exchange, calls } = makeExchangeWithFakeWs();
+
+        await exchange.watchOrderBook(SLUG);
+        expect(calls.watch).toEqual([SLUG]);
+
+        await exchange.unwatchOrderBook(SLUG);
+        expect(calls.unsubscribe).toEqual([SLUG]);
+    });
+
+    test('reports unwatchOrderBook as a supported capability', () => {
+        const exchange = new LimitlessExchange();
+        expect(exchange.has.unwatchOrderBook).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

`LimitlessExchange` never overrode `unwatchOrderBook`, so calling it always
threw `unwatchOrderBook() is not supported by Limitless` from the base class —
even though `LimitlessWebSocket.unsubscribe()` was already implemented.

This adds an `unwatchOrderBook` override that resolves the outcome slug
(mirroring the existing `watchOrderBook` override) and forwards it to the
websocket's `unsubscribe()`, which removes the `subscribe_market_prices`
subscription and drops the cached orderbook/price callbacks.

## Why

`watchOrderBook` opened a subscription that could never be torn down through
the public API, so consumers had no supported way to stop streaming a market's
orderbook. The websocket already exposed `unsubscribe()`; this simply wires it
into the exchange interface.

The capability now reports as supported automatically via the base class's
capability derivation (`exchange.has.unwatchOrderBook === true`).

## Tests

Added `core/test/unit/limitless-unwatch-orderbook.core.test.ts`:

- `watchOrderBook` then `unwatchOrderBook` forwards the resolved slug to
  `LimitlessWebSocket.unsubscribe()` (verified via a spy) instead of throwing.
- `exchange.has.unwatchOrderBook` now reports `true`.

```
# focused
npx jest -c jest.config.js test/unit/limitless-unwatch-orderbook.core.test.ts
  Tests: 2 passed, 2 total

# full core suite
npx jest -c jest.config.js
  Test Suites: 48 passed, 1 skipped, 49 total
  Tests: 812 passed, 3 skipped, 815 total

# type check
npx tsc --noEmit   # exit 0

# generators (no drift)
node core/scripts/check-exchange-drift.js   # No drift. All layers in sync.
node core/scripts/generate-compliance.js    # COMPLIANCE.md unchanged
```

Fixes #1660
