### PR TITLE
feat(rain): add fetchOrderBooks batch order-book fetch

### DIFF
--- a/core/src/exchanges/rain/index.ts
+++ b/core/src/exchanges/rain/index.ts
@@ -70,6 +70,8 @@ export class RainExchange extends PredictionMarketExchange {
     protected override readonly capabilityOverrides = {
         fetchSeries: false as const,
         fetchOrderBook: 'emulated' as const,
+        // Emulated batch: loops the single-outcome fetchOrderBook (no native batch endpoint).
+        fetchOrderBooks: 'emulated' as const,
         watchOrderBook: 'emulated' as const,
         watchTrades: 'emulated' as const,
         // Trading is on-chain via Rain SDK + viem. open/closed orders + fetchOrder
@@ -155,6 +157,14 @@ export class RainExchange extends PredictionMarketExchange {
         const raw = await this.fetcher.fetchRawMarket(parts[1]);
         if (!raw) return { bids: [], asks: [], timestamp: Date.now() };
         return this.normalizer.normalizeOrderBook(raw, outcomeId);
+    }
+
+    async fetchOrderBooks(outcomeIds: string[]): Promise<Record<string, OrderBook>> {
+        const response: Record<string, OrderBook> = {};
+        for (const outcomeId of outcomeIds) {
+            response[outcomeId] = await this.fetchOrderBook(outcomeId);
+        }
+        return response;
     }
 
     async fetchTrades(outcomeId: string, params: TradesParams | HistoryFilterParams): Promise<Trade[]> {

--- a/core/test/unit/rain-fetch-order-books.core.test.ts
+++ b/core/test/unit/rain-fetch-order-books.core.test.ts
@@ -1,0 +1,47 @@
+import { RainExchange } from '../../src/exchanges/rain';
+import type { OrderBook } from '../../src/types';
+
+/**
+ * Regression for #1666: RainExchange exposed a working single-outcome
+ * `fetchOrderBook` but never overrode the batch `fetchOrderBooks`, so calling
+ * it threw "Method fetchOrderBooks not implemented." and `has.fetchOrderBooks`
+ * reported false. The batch override loops the already-working single fetch and
+ * is reported as an emulated capability (matching `fetchOrderBook: 'emulated'`).
+ */
+describe('RainExchange.fetchOrderBooks', () => {
+    const BOOK_A: OrderBook = {
+        bids: [{ price: 0.4, size: 10 }],
+        asks: [],
+        timestamp: 1,
+    } as OrderBook;
+    const BOOK_B: OrderBook = {
+        bids: [],
+        asks: [{ price: 0.6, size: 5 }],
+        timestamp: 2,
+    } as OrderBook;
+
+    test('loops the single-outcome fetchOrderBook for each outcome id', async () => {
+        const exchange = new RainExchange();
+        const books: Record<string, OrderBook> = {
+            'rain:1:0': BOOK_A,
+            'rain:2:1': BOOK_B,
+        };
+        const calls: string[] = [];
+        // Stub the already-working single-outcome fetch so no network is hit.
+        (exchange as any).fetchOrderBook = async (outcomeId: string): Promise<OrderBook> => {
+            calls.push(outcomeId);
+            return books[outcomeId];
+        };
+
+        const ids = ['rain:1:0', 'rain:2:1'];
+        const result = await exchange.fetchOrderBooks(ids);
+
+        expect(calls).toEqual(ids);
+        expect(result).toEqual({ 'rain:1:0': BOOK_A, 'rain:2:1': BOOK_B });
+    });
+
+    test('reports fetchOrderBooks as a supported (emulated) capability', () => {
+        const exchange = new RainExchange();
+        expect(exchange.has.fetchOrderBooks).toBe('emulated');
+    });
+});


### PR DESCRIPTION
## What

`RainExchange` had a working single-outcome `fetchOrderBook`, but the batch
`fetchOrderBooks` fell through to the base class stub and threw
`Method fetchOrderBooks not implemented.`. `exchange.has.fetchOrderBooks` also
reported `false`.

This adds a `fetchOrderBooks(outcomeIds)` override that loops the already-working
`fetchOrderBook` and returns a `Record<string, OrderBook>` keyed by outcome id.

## Why

Rain has no native batch order-book endpoint, so the batch variant is emulated
by fanning out to the single-outcome fetch — the same way `fetchOrderBook`
itself is already declared `'emulated'`. To keep the capability map honest,
`fetchOrderBooks` is declared `'emulated'` in `capabilityOverrides` (rather than
letting it auto-derive to `true`), so it stays consistent with the single fetch.

## Tests

Added `core/test/unit/rain-fetch-order-books.core.test.ts`:

- `fetchOrderBooks([...])` calls the single-outcome `fetchOrderBook` once per id
  (verified via a stub) and returns a record matching those N individual calls.
- `exchange.has.fetchOrderBooks` now reports `'emulated'` instead of `false`.

```
# focused
npx jest -c jest.config.js test/unit/rain-fetch-order-books.core.test.ts
  Tests: 2 passed, 2 total

# full core suite
npx jest -c jest.config.js
  Test Suites: 48 passed, 1 skipped, 49 total
  Tests: 812 passed, 3 skipped, 815 total

# type check
npx tsc --noEmit   # exit 0

# generators (no drift)
node core/scripts/check-exchange-drift.js   # No drift. All layers in sync.
node core/scripts/generate-compliance.js    # COMPLIANCE.md unchanged
```

Fixes #1666
