### PR TITLE
fix(python): wrap malformed feed API errors

### DIFF
--- a/sdks/python/pmxt/feed_client.py
+++ b/sdks/python/pmxt/feed_client.py
@@ -146,9 +146,7 @@ class FeedClient:
         data = self._get("fetchOracleRound", {"feed": feed})
         return self._to_oracle_round(data)
 
-    def fetch_oracle_history(
-        self, feed: str, limit: Optional[int] = None
-    ) -> List[OracleRound]:
+    def fetch_oracle_history(self, feed: str, limit: Optional[int] = None) -> List[OracleRound]:
         params: Dict[str, Any] = {"feed": feed}
         if limit is not None:
             params["limit"] = limit
@@ -190,7 +188,12 @@ class FeedClient:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 body = json.loads(resp.read())
         except urllib.error.HTTPError as e:
-            body = json.loads(e.read()) if e.fp else {}
+            body = {}
+            if e.fp:
+                try:
+                    body = json.loads(e.read())
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    pass
             msg = body.get("error", e.reason)
             raise PmxtError(f"Feed API error ({e.code}): {msg}") from e
 

--- a/sdks/python/tests/test_feed_client.py
+++ b/sdks/python/tests/test_feed_client.py
@@ -1,6 +1,11 @@
+import io
 import json
+import urllib.error
 import urllib.request
 
+import pytest
+
+from pmxt.errors import PmxtError
 from pmxt.feed_client import FeedClient
 
 
@@ -35,3 +40,25 @@ def test_list_feeds_hits_the_root_endpoint(monkeypatch):
     assert captured["url"] == "http://localhost:3847/api/feeds/"
     assert captured["timeout"] == 30
     assert captured["headers"] == {}
+
+
+def test_http_error_with_non_json_body_raises_pmxt_error(monkeypatch):
+    error = urllib.error.HTTPError(
+        "https://api.pmxt.dev/api/feeds/",
+        502,
+        "Bad Gateway",
+        {},
+        io.BytesIO(b"<html>upstream unavailable</html>"),
+    )
+
+    def fake_urlopen(req, timeout=30):
+        raise error
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = FeedClient("chainlink", base_url="https://api.pmxt.dev")
+
+    with pytest.raises(PmxtError, match=r"Feed API error \(502\): Bad Gateway") as excinfo:
+        client.list_feeds()
+
+    assert excinfo.value.__cause__ is error

--- a/sdks/python/tests/test_feed_client.py
+++ b/sdks/python/tests/test_feed_client.py
@@ -62,3 +62,51 @@ def test_http_error_with_non_json_body_raises_pmxt_error(monkeypatch):
         client.list_feeds()
 
     assert excinfo.value.__cause__ is error
+
+
+def test_http_error_with_invalid_utf8_body_raises_pmxt_error(monkeypatch):
+    invalid_utf8 = b"\x80"
+    with pytest.raises(UnicodeDecodeError):
+        json.loads(invalid_utf8)
+
+    error = urllib.error.HTTPError(
+        "https://api.pmxt.dev/api/feeds/",
+        502,
+        "Bad Gateway",
+        {},
+        io.BytesIO(invalid_utf8),
+    )
+
+    def fake_urlopen(req, timeout=30):
+        raise error
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = FeedClient("chainlink", base_url="https://api.pmxt.dev")
+
+    with pytest.raises(PmxtError, match=r"Feed API error \(502\): Bad Gateway") as excinfo:
+        client.list_feeds()
+
+    assert excinfo.value.__cause__ is error
+
+
+def test_http_error_with_json_body_uses_api_error(monkeypatch):
+    error = urllib.error.HTTPError(
+        "https://api.pmxt.dev/api/feeds/",
+        429,
+        "Too Many Requests",
+        {},
+        io.BytesIO(b'{"error": "rate limit exceeded"}'),
+    )
+
+    def fake_urlopen(req, timeout=30):
+        raise error
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = FeedClient("chainlink", base_url="https://api.pmxt.dev")
+
+    with pytest.raises(PmxtError, match=r"Feed API error \(429\): rate limit exceeded") as excinfo:
+        client.list_feeds()
+
+    assert excinfo.value.__cause__ is error


### PR DESCRIPTION
## Summary

Keep Python FeedClient error handling aligned with the TypeScript SDK when a proxy or upstream returns a non-JSON error body. Malformed JSON and invalid UTF-8 now fall back to the HTTP reason while still raising the typed `PmxtError` and preserving the original `HTTPError` as the cause.

Fixes #1700.

## Testing

- `.venv/bin/pytest tests/test_feed_client.py -q` - 4 passed
- focused regressions cover malformed HTML, invalid UTF-8 (the `UnicodeDecodeError` path), and preservation of the existing valid-JSON API error behavior
- `.venv/bin/black --check pmxt/feed_client.py tests/test_feed_client.py`
- generated the Python OpenAPI client with OpenAPI Generator 7.18.0 before the original installation/test pass
- earlier full Python SDK pass on the same production change: 268 passed, 66 deselected
- wheel and sdist build; `twine check dist/*` passed
- `git diff --check`

Project-wide Mypy is not claimed as a clean gate: in the same Python 3.12.13 / Mypy 2.3.0 environment, both current main and this PR report the same 121 existing errors, plus the unsupported configured Python 3.8 warning. The PR adds no Mypy delta.

## AI Assistance Disclosure

OpenAI Codex assisted with issue investigation, implementation, regression-test creation, and validation. I reviewed the final diff and test results.
