### PR TITLE
fix(typescript): normalize hosted venue names before allowlist checks

### DIFF
--- a/sdks/typescript/pmxt/hosted-routing.ts
+++ b/sdks/typescript/pmxt/hosted-routing.ts
@@ -70,7 +70,7 @@ export interface HostedClientLike {
  */
 export function ensureHostedTradingSupported(client: HostedClientLike): void {
     if (!client.pmxtApiKey) return;
-    if (!HOSTED_TRADING_VENUES.has(client.exchangeName)) {
+    if (!HOSTED_TRADING_VENUES.has(client.exchangeName.toLowerCase())) {
         throw new NotSupported(
             `Hosted trading is only supported for Polymarket, Opinion, and Limitless; ${client.exchangeName} is not supported with pmxtApiKey.`,
         );

--- a/sdks/typescript/tests/hosted-dispatch.test.ts
+++ b/sdks/typescript/tests/hosted-dispatch.test.ts
@@ -21,6 +21,7 @@ jest.mock("../pmxt/hosted-typed-data", () => ({
 
 import { Polymarket } from "../pmxt/client";
 import {
+  ensureHostedTradingSupported,
   HOSTED_TRADING_BASE_URL,
 } from "../pmxt/hosted-routing";
 import { NotSupported } from "../pmxt/errors";
@@ -162,6 +163,16 @@ describe("hosted read methods raise MissingWalletAddress locally", () => {
 // --------------------------------------------------------------------------
 
 describe("hosted NotSupported", () => {
+  it.each(["Polymarket", "OPINION", "LiMiTlEsS"])(
+    "accepts supported venue %s regardless of casing",
+    (exchangeName) => {
+      expect(() => ensureHostedTradingSupported({
+        pmxtApiKey: PMXT_API_KEY,
+        exchangeName,
+      })).not.toThrow();
+    },
+  );
+
   it("fetchClosedOrders raises NotSupported without touching network", async () => {
     const spy = installFetchSpy(() => jsonResponse({}));
     const api = makePolymarket();


### PR DESCRIPTION
## Summary
- Normalize `exchangeName` before checking the hosted trading venue allowlist.
- Keep the original venue name in the unsupported venue error for diagnostics.
- Add regression coverage for supported venue names with mixed casing.

## Issue
Closes #1717

## Testing
- `git diff --check` passed.
- Focused Jest test was attempted with the repository Jest config, but the checkout does not contain the ignored generated TypeScript client under `sdks/typescript/generated/`.
- The repository OpenAPI generation command was attempted, but this environment has no Java Runtime, so the generated client could not be produced locally.
