### PR TITLE
fix(python): honor zero reconnect attempts

### DIFF
--- a/sdks/python/pmxt/ws_client.py
+++ b/sdks/python/pmxt/ws_client.py
@@ -140,7 +140,9 @@ class SidecarWsClient:
 
         # Connection attempts default to CONNECT_ATTEMPTS; callers may override
         # via the "maxReconnectAttempts" config key.
-        max_attempts = self._config.get("maxReconnectAttempts") or CONNECT_ATTEMPTS
+        max_attempts = self._config.get("maxReconnectAttempts")
+        if max_attempts is None:
+            max_attempts = CONNECT_ATTEMPTS
         # When "reconnectInterval" (ms) is not configured, preserve the fast
         # default backoff (0.25s, 0.5s, ...). Only a longer, explicitly
         # configured interval overrides it.

--- a/sdks/python/tests/test_ws_client.py
+++ b/sdks/python/tests/test_ws_client.py
@@ -4,7 +4,10 @@ import socket
 import sys
 import types
 
+import pytest
+
 import pmxt.ws_client as ws_client
+from pmxt.errors import PmxtError
 from pmxt.ws_client import SidecarWsClient, _WsSubscription, _connect_websocket
 
 
@@ -145,6 +148,34 @@ def test_ws_config_custom_url_and_reconnect_interval(monkeypatch):
     assert urls == ["ws://custom.example.com/ws", "ws://custom.example.com/ws"]
     # A configured reconnectInterval (2000ms) is applied between attempts.
     assert sleeps == [2.0]
+
+
+def test_ws_none_reconnect_attempts_uses_default(monkeypatch):
+    urls = []
+    _install_failing_websocket(monkeypatch, urls)
+
+    client = SidecarWsClient(
+        "http://localhost:3847", config={"maxReconnectAttempts": None}
+    )
+    with pytest.raises(OSError, match="handshake failure"):
+        with client._lock:
+            client._ensure_connected()
+
+    assert len(urls) == 3
+
+
+def test_ws_zero_reconnect_attempts_is_honored(monkeypatch):
+    urls = []
+    _install_failing_websocket(monkeypatch, urls)
+
+    client = SidecarWsClient(
+        "http://localhost:3847", config={"maxReconnectAttempts": 0}
+    )
+    with pytest.raises(PmxtError, match="WebSocket connection failed"):
+        with client._lock:
+            client._ensure_connected()
+
+    assert urls == []
 
 
 def test_ws_default_backoff_is_fast(monkeypatch):


### PR DESCRIPTION
## Summary

- default `maxReconnectAttempts` only when the option is missing or `None`
- preserve an explicit `0`, matching the TypeScript WebSocket client
- cover both the `None` default and zero-attempt behavior with regression tests

## Testing

- `python -m pytest sdks/python/tests/test_ws_client.py -q` (10 passed)
- `python -m pytest sdks/python/tests -q` (269 passed, 66 deselected)
- `npm test` (51 core suites passed; 822 core tests and 269 Python tests passed)

## AI assistance

OpenAI Codex assisted with implementation and verification. I reviewed the complete diff and take responsibility for the change.

Closes #1797