### PR TITLE
fix(python): log malformed hosted response bodies at debug

### DIFF
--- a/sdks/python/pmxt/_hosted_errors.py
+++ b/sdks/python/pmxt/_hosted_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable, Mapping, Sequence
 from typing import ClassVar, TYPE_CHECKING
 
@@ -19,6 +20,9 @@ from .errors import (
 
 if TYPE_CHECKING:
     import httpx
+
+
+logger = logging.getLogger(__name__)
 
 
 class HostedTradingError(PmxtError):
@@ -178,7 +182,8 @@ def _matches_status(expected_status: int | None, status: int) -> bool:
 def _json_payload(response: httpx.Response) -> object | None:
     try:
         return response.json()
-    except ValueError:
+    except ValueError as exc:
+        logger.debug("Could not parse hosted response body as JSON: %s", exc)
         return None
 
 

--- a/sdks/python/tests/test_hosted_errors.py
+++ b/sdks/python/tests/test_hosted_errors.py
@@ -1,3 +1,5 @@
+import logging
+
 import httpx
 import pytest
 
@@ -256,3 +258,16 @@ def test_hosted_exceptions_also_catch_as_legacy_base(error_class, legacy_base):
     assert issubclass(error_class, legacy_base)
     assert issubclass(error_class, HostedTradingError)
     assert issubclass(error_class, PmxtError)
+
+
+def test_malformed_response_body_is_logged_at_debug(caplog):
+    response = _response(500, text_body="<html>502 Bad Gateway</html>")
+
+    with caplog.at_level(logging.DEBUG, logger="pmxt._hosted_errors"):
+        with pytest.raises(HostedTradingError):
+            raise_from_response(response)
+
+    assert any(
+        "Could not parse hosted response body as JSON" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
Fixes #1792

`_json_payload` in `sdks/python/pmxt/_hosted_errors.py` swallowed a `ValueError` from `response.json()` and returned `None` with no logging. When the hosted trading API returned a non-JSON or malformed body, the resulting `HostedTradingError` lost all detail about the raw response, which makes backend contract changes and malformed error responses harder to diagnose.

This adds a module logger and a `logger.debug` line in the except path so the parse failure is recorded before falling back to `None`. Behavior is otherwise unchanged: the function still returns `None` and the error mapping flow is untouched.

I used `%s`-style logging to match the stdlib logging already used in the SDK (`ws_client.py`) rather than the dict-arg form in the issue, since that form doesn't fit stdlib `%` formatting.

Added a test in `tests/test_hosted_errors.py` that drives a malformed 5xx body through `raise_from_response` and asserts the debug record is emitted while the `HostedTradingError` still raises. Verified locally: the full `test_hosted_errors.py` suite passes (29 tests), and the new test fails without the log line.
