### PR TITLE
fix: forward Baozi per-request RPC URL

### DIFF
--- a/core/src/BaseExchange.ts
+++ b/core/src/BaseExchange.ts
@@ -401,6 +401,9 @@ export interface ExchangeCredentials {
 
     // Optional base URL override for venue API (e.g., proxy for geo-restricted venues)
     baseUrl?: string;
+
+    // Optional blockchain RPC override for venues backed by an on-chain client.
+    rpcUrl?: string;
 }
 
 export interface ExchangeOptions {

--- a/core/src/server/app.ts
+++ b/core/src/server/app.ts
@@ -437,7 +437,8 @@ export function createApp(options: CreateAppOptions = {}): Express {
         credentials &&
         (credentials.privateKey ||
           credentials.apiKey ||
-          credentials.apiToken)
+          credentials.apiToken ||
+          credentials.rpcUrl)
       ) {
         exchange = createExchange(exchangeName, credentials);
       } else {

--- a/core/src/server/exchange-factory.ts
+++ b/core/src/server/exchange-factory.ts
@@ -85,8 +85,11 @@ export function createExchange(
       });
     case "baozi":
       return new BaoziExchange({
-        privateKey:
-          credentials?.privateKey || process.env.BAOZI_PRIVATE_KEY,
+        credentials: {
+          privateKey:
+            credentials?.privateKey || process.env.BAOZI_PRIVATE_KEY,
+        },
+        rpcUrl: credentials?.rpcUrl,
       });
     case "myriad":
       return new MyriadExchange({

--- a/core/test/unit/exchange-factory.test.ts
+++ b/core/test/unit/exchange-factory.test.ts
@@ -13,6 +13,9 @@ const getFetcher = (exchange: unknown): Record<string, unknown> | undefined =>
 const getBaseUrl = (exchange: unknown): string | undefined =>
     (exchange as { baseUrl?: string }).baseUrl;
 
+const getRpcEndpoint = (exchange: unknown): string | undefined =>
+    (exchange as { connection?: { rpcEndpoint?: string } }).connection?.rpcEndpoint;
+
 const withEnv = <T>(env: NodeJS.ProcessEnv, run: () => T): T => {
     const originalEnv = process.env;
     process.env = { ...originalEnv, ...env };
@@ -24,6 +27,14 @@ const withEnv = <T>(env: NodeJS.ProcessEnv, run: () => T): T => {
 };
 
 describe('createExchange', () => {
+    test('baozi forwards a per-request RPC URL to its Solana connection', () => {
+        const exchange = createExchange('baozi', {
+            rpcUrl: 'https://baozi-rpc.test.local',
+        });
+
+        expect(getRpcEndpoint(exchange)).toBe('https://baozi-rpc.test.local');
+    });
+
     test('kalshi-demo prefers demo credentials before production fallbacks', () => {
         withEnv(
             {


### PR DESCRIPTION
## Summary
- add rpcUrl to the core per-request credential shape
- make RPC-only sidecar requests construct a per-request exchange instead of reusing the cached default
- forward the override into BaoziExchange while preserving the existing private-key fallback
- add a regression test that verifies the Solana connection receives the caller's endpoint

This fixes the factory/sidecar half of the RPC override path. SDK constructor exposure remains tracked separately in #854.

## Verification
- npm test --workspace=pmxt-core -- --runInBand test/unit/exchange-factory.test.ts (10 tests passed)
- npm run build --workspace=pmxt-core

Closes #1679