### PR TITLE
fix(python): export hosted trading errors

### DIFF
--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -40,6 +40,18 @@ from .errors import (
     NetworkError,
     ExchangeNotAvailable,
 )
+from ._hosted_errors import (
+    HostedTradingError,
+    InsufficientEscrowBalance,
+    OrderSizeTooSmall,
+    InvalidApiKey,
+    OutcomeNotFound,
+    CatalogUnavailable,
+    BuiltOrderExpired,
+    InvalidSignature,
+    NoLiquidity,
+    MissingWalletAddress,
+)
 from .models import (
     UnifiedMarket,
     UnifiedEvent,
@@ -225,6 +237,16 @@ __all__ = [
     "ValidationError",
     "NetworkError",
     "ExchangeNotAvailable",
+    "HostedTradingError",
+    "InsufficientEscrowBalance",
+    "OrderSizeTooSmall",
+    "InvalidApiKey",
+    "OutcomeNotFound",
+    "CatalogUnavailable",
+    "BuiltOrderExpired",
+    "InvalidSignature",
+    "NoLiquidity",
+    "MissingWalletAddress",
     # Data Models
     "UnifiedMarket",
     "UnifiedEvent",

--- a/sdks/python/tests/test_public_exports.py
+++ b/sdks/python/tests/test_public_exports.py
@@ -2,6 +2,28 @@ import ast
 from pathlib import Path
 
 
+def test_hosted_trading_errors_are_top_level_public_exports():
+    import pmxt
+    from pmxt import _hosted_errors
+
+    hosted_error_names = {
+        "HostedTradingError",
+        "InsufficientEscrowBalance",
+        "OrderSizeTooSmall",
+        "InvalidApiKey",
+        "OutcomeNotFound",
+        "CatalogUnavailable",
+        "BuiltOrderExpired",
+        "InvalidSignature",
+        "NoLiquidity",
+        "MissingWalletAddress",
+    }
+
+    assert hosted_error_names <= set(pmxt.__all__)
+    for name in hosted_error_names:
+        assert getattr(pmxt, name) is getattr(_hosted_errors, name)
+
+
 def test_websocket_return_types_are_public_exports():
     init_path = Path(__file__).resolve().parents[1] / "pmxt" / "__init__.py"
     tree = ast.parse(init_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- re-export the hosted-trading error hierarchy from the Python package root
- include all ten names in `pmxt.__all__`
- verify every top-level symbol is the canonical class from `pmxt._hosted_errors`

## Verification

- `python -m pytest sdks/python/tests -q`
- 268 passed, 66 deselected

Closes #1820