### PR TITLE
fix(typescript): export ServerManagerOptions

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -35,6 +35,7 @@ export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedCli
 export { Router } from "./pmxt/router.js";
 export type { RouterOptions } from "./pmxt/router.js";
 export { ServerManager } from "./pmxt/server-manager.js";
+export type { ServerManagerOptions } from "./pmxt/server-manager.js";
 export {
     HOSTED_URL,
     LOCAL_URL,

--- a/sdks/typescript/tests/public-exports.test.ts
+++ b/sdks/typescript/tests/public-exports.test.ts
@@ -1,5 +1,6 @@
 import * as pmxt from '../index';
 import { FeedClient as DirectFeedClient } from '../pmxt/feed-client';
+import type { ServerManagerOptions } from '../index';
 
 describe('public exports', () => {
   it('exports FeedClient as a top-level named export', () => {
@@ -26,5 +27,15 @@ describe('public exports', () => {
     const exchange = new pmxt.Polymarket_us({ autoStartServer: false });
     expect(exchange).toBeInstanceOf(pmxt.PolymarketUS);
     expect(exchange.exchangeName).toBe('polymarket_us');
+  });
+
+  it('exports ServerManagerOptions for typed constructor configuration', () => {
+    const options: ServerManagerOptions = {
+      baseUrl: 'http://localhost:4123',
+      maxRetries: 2,
+      retryDelayMs: 10,
+    };
+
+    expect(new pmxt.ServerManager(options)).toBeInstanceOf(pmxt.ServerManager);
   });
 });


### PR DESCRIPTION
## Summary

- export `ServerManagerOptions` from the TypeScript package root
- add compile-time regression coverage using the public entry point

This makes the options type available alongside `ServerManager`, matching the existing root exports for `RouterOptions`, `FeedClientOptions`, and other constructor option types.

## Verification

- `npm test --workspace=pmxtjs -- --runInBand --watchman=false tests/public-exports.test.ts` (6 tests passed)
- `npm run build --workspace=pmxtjs` (CommonJS and ESM builds passed)
- `git diff --check`

The broader TypeScript run completed 12 of 17 suites (67 of 94 tests). Five unrelated network-mocking suites could not install their fetch spies because this local Node 26/Jest environment did not expose `global.fetch` inside the Jest sandbox; the changed public-export suite and both package builds pass.

Closes #1840
