### PR TITLE
fix(python): avoid masking health check errors

### DIFF
--- a/sdks/python/pmxt/server_manager.py
+++ b/sdks/python/pmxt/server_manager.py
@@ -15,6 +15,7 @@ This ensures zero-configuration usage across all SDKs.
 
 import os
 import json
+import logging
 import time
 import subprocess
 import shutil
@@ -22,7 +23,8 @@ import threading
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 import urllib.request
-import urllib.error
+
+logger = logging.getLogger(__name__)
 
 
 class ServerManager:
@@ -495,7 +497,8 @@ class ServerManager:
                     return data.get('status') == 'ok'
             
             return False
-        except (urllib.error.URLError, urllib.error.HTTPError, Exception):
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Health check failed for port %s: %s", port, exc)
             return False
     
     def get_server_info(self) -> Optional[Dict[str, Any]]:

--- a/sdks/python/tests/test_server_manager.py
+++ b/sdks/python/tests/test_server_manager.py
@@ -1,3 +1,6 @@
+import logging
+import urllib.error
+
 import pytest
 
 from pmxt.server_manager import ServerManager
@@ -20,3 +23,29 @@ def test_wait_for_health_requires_current_home_lock(monkeypatch, tmp_path):
 
     with pytest.raises(Exception, match="Server failed to become healthy"):
         manager._wait_for_health()
+
+
+def test_check_health_logs_expected_request_failures(monkeypatch, caplog):
+    manager = ServerManager()
+
+    def fail_request(*args, **kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("pmxt.server_manager.urllib.request.urlopen", fail_request)
+
+    with caplog.at_level(logging.DEBUG, logger="pmxt.server_manager"):
+        assert manager._check_health(3847) is False
+
+    assert "Health check failed for port 3847" in caplog.text
+
+
+def test_check_health_does_not_mask_unexpected_errors(monkeypatch):
+    manager = ServerManager()
+
+    def fail_request(*args, **kwargs):
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr("pmxt.server_manager.urllib.request.urlopen", fail_request)
+
+    with pytest.raises(RuntimeError, match="unexpected failure"):
+        manager._check_health(3847)


### PR DESCRIPTION
## What problem this solves

The Python sidecar health check caught every `Exception`, which hid unexpected programming errors and made all failures indistinguishable from an unavailable server.

## Why this change was made

The handler now catches only expected I/O and malformed-response failures, records them at debug level, and lets unexpected exceptions propagate.

## User impact

Normal connection and malformed-health-response failures still report an unhealthy server, while unrelated defects retain their original traceback for diagnosis.

## Evidence

- `python -m pytest tests/test_server_manager.py -q` — 4 passed
- `python -m mypy --follow-imports=skip --ignore-missing-imports sdks/python/pmxt/server_manager.py` — passed
- `python -m black --check sdks/python/tests/test_server_manager.py` — passed

Fixes pmxt-dev/pmxt#1790