### PR TITLE
fix(ts-sdk): add matched event cluster params alias

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -1110,6 +1110,9 @@ export interface FetchMatchedEventClustersParams extends MatchedClusterFilterPar
     url?: string;
 }
 
+// Alias for SDK consistency with Python
+export type MatchedEventClusterParams = FetchMatchedEventClustersParams;
+
 /** Pairwise edge used to build a matched market cluster. */
 export interface MatchedMarketClusterEdge {
     marketAId: string;


### PR DESCRIPTION
## Summary

- Add `MatchedEventClusterParams` as a TypeScript alias for the generated `FetchMatchedEventClustersParams` type.
- Restore the documented public type name without changing generated API behavior.

Closes #1916

## Testing

- Regenerated and built the TypeScript SDK with the repository's OpenAPI generator workflow.
- Ran the TypeScript SDK Jest suite — 17 suites and 93 tests passed.
