### PR TITLE
docs: add self-hosted TypeScript examples

### DIFF
--- a/core/test/unit/docs-copy-paste-samples.test.js
+++ b/core/test/unit/docs-copy-paste-samples.test.js
@@ -96,6 +96,26 @@ describe('Documentation copy-paste samples', () => {
     expect(snippet).toContain('new Polymarket');
   });
 
+  test('self-hosted guide pairs Python workflows with TypeScript examples', () => {
+    const selfHosted = readDoc('docs/guides/self-hosted.mdx');
+    const configuration = readDoc('docs/api-reference/configuration.mdx');
+
+    expect(selfHosted).toContain('await pmxt.server.start()');
+    expect(selfHosted).toContain('const poly = new Polymarket({ privateKey: "0xYourPrivateKey..." });');
+    expect(selfHosted).toContain('const kalshi = new Kalshi({');
+    expect(selfHosted).toContain('apiKey: "...",');
+    expect(selfHosted).toContain('const smarkets = new Smarkets({');
+    expect(selfHosted).toContain('const baozi = new Baozi({ privateKey: "<base58 secret key>" });');
+    expect(selfHosted).toContain('const poly = new Polymarket({ privateKey: "0x..." });');
+    expect(selfHosted).toContain('const kalshi = new Kalshi({ apiKey: "...", privateKey: "..." });');
+    expect(configuration).toContain(
+      '| `api_key_id`, `private_key_pem` | `apiKey`, `privateKey` | `str` | Kalshi RSA credentials. |',
+    );
+    expect(configuration).toContain(
+      '| `email`, `password` | `apiKey`, `privateKey` | `str` | Smarkets session credentials. |',
+    );
+  });
+
   test('standalone Python README self-hosted examples import os before getenv use', () => {
     const readme = readDoc('readme.md');
     const snippets = [

--- a/docs/api-reference/configuration.mdx
+++ b/docs/api-reference/configuration.mdx
@@ -78,8 +78,8 @@ When `pmxt_api_key` is absent, the SDK enters self-hosted mode and routes throug
 | Python kwarg | TypeScript key | Type | Description |
 | ------------ | -------------- | ---- | ----------- |
 | `private_key` | `privateKey` | `str` | EVM private key, for Polymarket / Limitless / Probable / Opinion / etc. |
-| `api_key_id`, `private_key_pem` | `apiKeyId`, `privateKeyPem` | `str` | Kalshi RSA credentials. |
-| `email`, `password` | `email`, `password` | `str` | Smarkets session credentials. |
+| `api_key_id`, `private_key_pem` | `apiKey`, `privateKey` | `str` | Kalshi RSA credentials. |
+| `email`, `password` | `apiKey`, `privateKey` | `str` | Smarkets session credentials. |
 | `local_port` | `localPort` | `int` | Override the default pmxt-core port (`3847`). |
 
 See [Self-hosted](/guides/self-hosted) for per-venue credential examples.

--- a/docs/guides/self-hosted.mdx
+++ b/docs/guides/self-hosted.mdx
@@ -65,7 +65,8 @@ The first call blocks briefly while the local server warms up; subsequent calls 
 
 For lifecycle control (start, stop, restart, status, logs), use the `server` namespace. See [Server Management](/sdk/server) for the full reference.
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 pmxt.server.start()       # idempotent
@@ -76,6 +77,18 @@ pmxt.server.restart()
 pmxt.server.logs(20)
 ```
 
+```typescript TypeScript
+import pmxt from "pmxtjs";
+
+await pmxt.server.start();       // idempotent
+await pmxt.server.health();      // boolean
+await pmxt.server.status();      // structured snapshot
+await pmxt.server.stop();
+await pmxt.server.restart();
+await pmxt.server.logs(20);
+```
+</CodeGroup>
+
 Most users never call these — creating an exchange instance auto-starts the server.
 
 ## 4. Per-venue raw credentials
@@ -84,7 +97,8 @@ Self-hosted unlocks the full venue-credential surface. Pass credentials directly
 
 ### Polymarket — EVM private key
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 poly = pmxt.Polymarket(private_key="0xYourPrivateKey...")
@@ -98,9 +112,25 @@ order = poly.create_order(
 )
 ```
 
+```typescript TypeScript
+import { Polymarket } from "pmxtjs";
+
+const poly = new Polymarket({ privateKey: "0xYourPrivateKey..." });
+
+const order = await poly.createOrder({
+  outcome: market.yes!,
+  side: "buy",
+  type: "limit",
+  price: 0.42,
+  amount: 100,
+});
+```
+</CodeGroup>
+
 ### Kalshi — RSA key pair
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 kalshi = pmxt.Kalshi(
@@ -109,9 +139,20 @@ kalshi = pmxt.Kalshi(
 )
 ```
 
+```typescript TypeScript
+import { Kalshi } from "pmxtjs";
+
+const kalshi = new Kalshi({
+  apiKey: "...",
+  privateKey: "-----BEGIN RSA PRIVATE KEY-----\n...",
+});
+```
+</CodeGroup>
+
 ### Limitless / Probable / Opinion (self-hosted) — EVM private key
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 limitless = pmxt.Limitless(private_key="0x...")
@@ -119,21 +160,49 @@ probable  = pmxt.Probable(private_key="0x...")
 opinion   = pmxt.Opinion(private_key="0x...")
 ```
 
+```typescript TypeScript
+import { Limitless, Opinion, Probable } from "pmxtjs";
+
+const limitless = new Limitless({ privateKey: "0x..." });
+const probable = new Probable({ privateKey: "0x..." });
+const opinion = new Opinion({ privateKey: "0x..." });
+```
+</CodeGroup>
+
 ### Smarkets — email + password
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 smarkets = pmxt.Smarkets(email="you@example.com", password="...")
 ```
 
+```typescript TypeScript
+import { Smarkets } from "pmxtjs";
+
+const smarkets = new Smarkets({
+  apiKey: "you@example.com",
+  privateKey: "...",
+});
+```
+</CodeGroup>
+
 ### Baozi — Solana keypair
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 baozi = pmxt.Baozi(private_key="<base58 secret key>")
 ```
+
+```typescript TypeScript
+import { Baozi } from "pmxtjs";
+
+const baozi = new Baozi({ privateKey: "<base58 secret key>" });
+```
+</CodeGroup>
 
 See [Supported Venues](/concepts/venues) for the full credential matrix.
 
@@ -155,13 +224,23 @@ See [API Reference / Configuration](/api-reference/configuration) for the full e
 
 A single pmxt-core process can serve every venue. Construct multiple exchange clients against the same server — they all share the local process.
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 poly = pmxt.Polymarket(private_key="0x...")
 kalshi = pmxt.Kalshi(api_key_id="...", private_key_pem="...")
 # Both clients reuse the same pmxt-core process at http://localhost:3847
 ```
+
+```typescript TypeScript
+import { Kalshi, Polymarket } from "pmxtjs";
+
+const poly = new Polymarket({ privateKey: "0x..." });
+const kalshi = new Kalshi({ apiKey: "...", privateKey: "..." });
+// Both clients reuse the same pmxt-core process at http://localhost:3847
+```
+</CodeGroup>
 
 ## 7. Production deployment
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2091,7 +2091,8 @@ The first call blocks briefly while the local server warms up; subsequent calls 
 
 For lifecycle control (start, stop, restart, status, logs), use the `server` namespace. See [Server Management](https://pmxt.dev/docs/sdk/server) for the full reference.
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 pmxt.server.start()       # idempotent
@@ -2102,6 +2103,18 @@ pmxt.server.restart()
 pmxt.server.logs(20)
 ```
 
+```typescript TypeScript
+import pmxt from "pmxtjs";
+
+await pmxt.server.start();       // idempotent
+await pmxt.server.health();      // boolean
+await pmxt.server.status();      // structured snapshot
+await pmxt.server.stop();
+await pmxt.server.restart();
+await pmxt.server.logs(20);
+```
+</CodeGroup>
+
 Most users never call these — creating an exchange instance auto-starts the server.
 
 #### 4. Per-venue raw credentials
@@ -2110,7 +2123,8 @@ Self-hosted unlocks the full venue-credential surface. Pass credentials directly
 
 ##### Polymarket — EVM private key
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 poly = pmxt.Polymarket(private_key="0xYourPrivateKey...")
@@ -2124,9 +2138,25 @@ amount=100,
 )
 ```
 
+```typescript TypeScript
+import { Polymarket } from "pmxtjs";
+
+const poly = new Polymarket({ privateKey: "0xYourPrivateKey..." });
+
+const order = await poly.createOrder({
+  outcome: market.yes!,
+  side: "buy",
+  type: "limit",
+  price: 0.42,
+  amount: 100,
+});
+```
+</CodeGroup>
+
 ##### Kalshi — RSA key pair
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 kalshi = pmxt.Kalshi(
@@ -2135,9 +2165,20 @@ private_key_pem="-----BEGIN RSA PRIVATE KEY-----\n...",
 )
 ```
 
+```typescript TypeScript
+import { Kalshi } from "pmxtjs";
+
+const kalshi = new Kalshi({
+  apiKey: "...",
+  privateKey: "-----BEGIN RSA PRIVATE KEY-----\n...",
+});
+```
+</CodeGroup>
+
 ##### Limitless / Probable / Opinion (self-hosted) — EVM private key
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 limitless = pmxt.Limitless(private_key="0x...")
@@ -2145,21 +2186,49 @@ probable  = pmxt.Probable(private_key="0x...")
 opinion   = pmxt.Opinion(private_key="0x...")
 ```
 
+```typescript TypeScript
+import { Limitless, Opinion, Probable } from "pmxtjs";
+
+const limitless = new Limitless({ privateKey: "0x..." });
+const probable = new Probable({ privateKey: "0x..." });
+const opinion = new Opinion({ privateKey: "0x..." });
+```
+</CodeGroup>
+
 ##### Smarkets — email + password
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 smarkets = pmxt.Smarkets(email="you@example.com", password="...")
 ```
 
+```typescript TypeScript
+import { Smarkets } from "pmxtjs";
+
+const smarkets = new Smarkets({
+  apiKey: "you@example.com",
+  privateKey: "...",
+});
+```
+</CodeGroup>
+
 ##### Baozi — Solana keypair
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 baozi = pmxt.Baozi(private_key="<base58 secret key>")
 ```
+
+```typescript TypeScript
+import { Baozi } from "pmxtjs";
+
+const baozi = new Baozi({ privateKey: "<base58 secret key>" });
+```
+</CodeGroup>
 
 See [Supported Venues](https://pmxt.dev/docs/concepts/venues) for the full credential matrix.
 
@@ -2182,13 +2251,23 @@ See [API Reference / Configuration](https://pmxt.dev/docs/api-reference/configur
 
 A single pmxt-core process can serve every venue. Construct multiple exchange clients against the same server — they all share the local process.
 
-```python
+<CodeGroup>
+```python Python
 import pmxt
 
 poly = pmxt.Polymarket(private_key="0x...")
 kalshi = pmxt.Kalshi(api_key_id="...", private_key_pem="...")
 # Both clients reuse the same pmxt-core process at http://localhost:3847
 ```
+
+```typescript TypeScript
+import { Kalshi, Polymarket } from "pmxtjs";
+
+const poly = new Polymarket({ privateKey: "0x..." });
+const kalshi = new Kalshi({ apiKey: "...", privateKey: "..." });
+// Both clients reuse the same pmxt-core process at http://localhost:3847
+```
+</CodeGroup>
 
 #### 7. Production deployment
 


### PR DESCRIPTION
## Summary

- pair the self-hosted server, credential, and multi-exchange Python snippets with TypeScript examples
- use the TypeScript SDK's actual public credential keys (`apiKey` and `privateKey`)
- correct the configuration table's stale TypeScript credential aliases
- regenerate `docs/llms-full.txt`
- add a regression test for the documented TypeScript paths

This change was AI-assisted and manually verified against `ExchangeOptions`, the Kalshi and Smarkets authentication adapters, and the server namespace exports.

Closes #1920

## Verification

- `npm run docs:llms`
- `npm test --workspace=pmxt-core -- --runInBand core/test/unit/docs-copy-paste-samples.test.js core/test/unit/llms-docs.test.js`
- `git diff --check`

Node.js 20.19.2 was used for the checks.