### PR TITLE
docs: add Kalshi demo to streaming venue lists

### DIFF
--- a/docs/api-reference/watch-order-book.mdx
+++ b/docs/api-reference/watch-order-book.mdx
@@ -7,7 +7,7 @@ description: Stream real-time orderbook updates for a single outcome via WebSock
 **WebSocket endpoint** — This method uses WebSocket streaming, not HTTP. Connect to `wss://api.pmxt.dev/ws?apiKey=YOUR_KEY` (hosted) or `ws://localhost:3847/ws` (local server).
 </Info>
 
-Supported venues: `polymarket`, `kalshi`, `limitless`, `opinion`, `polymarket_us`, `probable`, `baozi`, `myriad`, `gemini-titan`, `rain`, `hunch`.
+Supported venues: `polymarket`, `kalshi`, `kalshi-demo`, `limitless`, `opinion`, `polymarket_us`, `probable`, `baozi`, `myriad`, `gemini-titan`, `rain`, `hunch`.
 
 ## Parameters
 

--- a/docs/api-reference/watch-order-books.mdx
+++ b/docs/api-reference/watch-order-books.mdx
@@ -7,7 +7,7 @@ description: Stream real-time orderbook updates for multiple outcomes via WebSoc
 **WebSocket endpoint** — This method uses WebSocket streaming, not HTTP. Connect to `wss://api.pmxt.dev/ws?apiKey=YOUR_KEY` (hosted) or `ws://localhost:3847/ws` (local server).
 </Info>
 
-Supported venues: `polymarket`, `kalshi`, `limitless`, `opinion`, `polymarket_us`, `probable`, `baozi`, `myriad`, `gemini-titan`, `rain`, `hunch`.
+Supported venues: `polymarket`, `kalshi`, `kalshi-demo`, `limitless`, `opinion`, `polymarket_us`, `probable`, `baozi`, `myriad`, `gemini-titan`, `rain`, `hunch`.
 
 ## Parameters
 

--- a/docs/api-reference/watch-trades.mdx
+++ b/docs/api-reference/watch-trades.mdx
@@ -7,7 +7,7 @@ description: Stream real-time trade updates for a single outcome via WebSocket
 **WebSocket endpoint** — This method uses WebSocket streaming, not HTTP. Connect to `wss://api.pmxt.dev/ws?apiKey=YOUR_KEY` (hosted) or `ws://localhost:3847/ws` (local server).
 </Info>
 
-Supported venues: `polymarket`, `kalshi`, `limitless`, `opinion`, `polymarket_us`, `myriad`, `gemini-titan`, `rain`, `hunch`.
+Supported venues: `polymarket`, `kalshi`, `kalshi-demo`, `limitless`, `opinion`, `polymarket_us`, `myriad`, `gemini-titan`, `rain`, `hunch`.
 
 ## Parameters
 


### PR DESCRIPTION
## What & why

Add `kalshi-demo` to the supported venue lists for `watchOrderBook`, `watchOrderBooks`, and `watchTrades`. The demo exchange inherits these streaming methods from Kalshi, so the API reference should advertise the same capability.

Closes #1928.

## Test plan

- `npm run docs:llms`
- verified the three streaming pages each contain exactly one supported-venues line including `kalshi-demo`
- `git diff --check`

## AI assistance

AI assistance was used to inspect the documented capability path, make this scoped documentation update, and run validation. I reviewed the final diff and results before submission.