### PR TITLE
fix(router): forward event status filter

### DIFF
--- a/core/src/router/Router.ts
+++ b/core/src/router/Router.ts
@@ -197,6 +197,7 @@ export class Router extends PredictionMarketExchange {
             category: params?.category,
             limit: params?.limit,
             offset: params?.offset,
+            closed: params?.status === 'closed' || params?.status === 'inactive',
             sourceExchange: params?.sourceExchange ?? params?.exchange,
         });
         if (!Array.isArray(response)) {

--- a/core/test/pipeline/router-local-mock-matches.test.ts
+++ b/core/test/pipeline/router-local-mock-matches.test.ts
@@ -115,3 +115,29 @@ describe('Router local mock match lookup', () => {
         }
     });
 });
+
+describe('Router hosted event filters', () => {
+    test.each([
+        ['closed', 'true'],
+        ['inactive', 'true'],
+        ['active', null],
+        ['all', null],
+    ] as const)('maps event status %s to closed=%s', async (status, expectedClosed) => {
+        let capturedUrl: URL | undefined;
+        const { server, baseUrl } = await startRawServer((req, res) => {
+            capturedUrl = new URL(req.url ?? '/', 'http://localhost');
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ data: [] }));
+        });
+
+        try {
+            const router = new Router({ apiKey: 'test', baseUrl });
+            await expect(router.fetchEvents({ status, query: 'election' })).resolves.toEqual([]);
+            expect(capturedUrl?.pathname).toBe('/v0/events');
+            expect(capturedUrl?.searchParams.get('q')).toBe('election');
+            expect(capturedUrl?.searchParams.get('closed')).toBe(expectedClosed);
+        } finally {
+            await stopTestServer(server);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- forward Router event status into the existing hosted `closed` query flag
- cover `closed`, `inactive`, `active`, and `all` through the local raw-HTTP Router harness
- preserve the existing event query parameter while exercising the real client serialization boundary

Fixes #1961.

## Validation

- regression before the production change: focused suite failed 2 tests and passed 7; only `closed` and `inactive` lacked `closed=true`
- `npm test --workspace=pmxt-core -- --runInBand test/pipeline/router-local-mock-matches.test.ts` - 9/9 passed
- `npm run build --workspace=pmxt-core` - passed
- `git diff --check` - passed (Windows autocrlf notices only)
- full core Jest branch: 48 passed, 3 failed, 1 pending suites; 821 passed, 5 failed, 3 pending tests
- untouched pinned-main comparison: the same 3 failed/1 pending suites and same 5 failed/3 pending tests, with 817 passing tests; the branch adds exactly four passes

The identical baseline failures are three documentation-generation assertions, one llms-docs synchronization assertion, and one stale-lock assertion. Generated documentation/compliance drift from the broad run was restored; this PR changes only the Router mapping and focused test.

`npm ci --workspace=pmxt-core` reported 46 existing audit findings (14 low, 15 moderate, 13 high, 4 critical). This PR does not change dependencies or attempt unrelated remediation.

## Provenance

This contribution was autonomously authored and validated by an OpenAI Codex agent operating the LunaMeerkats account. No human authorship or pre-submission review is claimed.
