### PR TITLE
feat(python): export hosted trading errors

### DIFF
--- a/sdks/python/pmxt/__init__.py
+++ b/sdks/python/pmxt/__init__.py
@@ -40,6 +40,18 @@ from .errors import (
     NetworkError,
     ExchangeNotAvailable,
 )
+from ._hosted_errors import (
+    HostedTradingError,
+    InsufficientEscrowBalance,
+    OrderSizeTooSmall,
+    InvalidApiKey,
+    OutcomeNotFound,
+    CatalogUnavailable,
+    BuiltOrderExpired,
+    InvalidSignature,
+    NoLiquidity,
+    MissingWalletAddress,
+)
 from .models import (
     UnifiedMarket,
     UnifiedEvent,
@@ -225,6 +237,16 @@ __all__ = [
     "ValidationError",
     "NetworkError",
     "ExchangeNotAvailable",
+    "HostedTradingError",
+    "InsufficientEscrowBalance",
+    "OrderSizeTooSmall",
+    "InvalidApiKey",
+    "OutcomeNotFound",
+    "CatalogUnavailable",
+    "BuiltOrderExpired",
+    "InvalidSignature",
+    "NoLiquidity",
+    "MissingWalletAddress",
     # Data Models
     "UnifiedMarket",
     "UnifiedEvent",

--- a/sdks/python/tests/test_public_exports.py
+++ b/sdks/python/tests/test_public_exports.py
@@ -2,6 +2,49 @@ import ast
 from pathlib import Path
 
 
+def test_hosted_trading_errors_are_top_level_public_exports():
+    import pmxt
+    from pmxt import _hosted_errors
+
+    init_path = Path(__file__).resolve().parents[1] / "pmxt" / "__init__.py"
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    expected = {
+        "HostedTradingError",
+        "InsufficientEscrowBalance",
+        "OrderSizeTooSmall",
+        "InvalidApiKey",
+        "OutcomeNotFound",
+        "CatalogUnavailable",
+        "BuiltOrderExpired",
+        "InvalidSignature",
+        "NoLiquidity",
+        "MissingWalletAddress",
+    }
+    imported_hosted_errors = set()
+    public_exports = set()
+
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "_hosted_errors":
+            imported_hosted_errors.update(alias.name for alias in node.names)
+        elif (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "__all__"
+            and isinstance(node.value, ast.List)
+        ):
+            public_exports.update(
+                item.value
+                for item in node.value.elts
+                if isinstance(item, ast.Constant) and isinstance(item.value, str)
+            )
+
+    assert expected <= imported_hosted_errors
+    assert expected <= public_exports
+    for name in expected:
+        assert getattr(pmxt, name) is getattr(_hosted_errors, name)
+
+
 def test_websocket_return_types_are_public_exports():
     init_path = Path(__file__).resolve().parents[1] / "pmxt" / "__init__.py"
     tree = ast.parse(init_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- export all ten hosted trading error classes from the Python package root
- add regression coverage for direct imports, `__all__`, and class-object identity
- preserve the existing implementations and lazy `pmxt.errors` exports

## Why

Python users currently need a private `pmxt._hosted_errors` import to catch specific hosted trading failures. This gives them the same stable package-root API available in the TypeScript SDK.

Closes #1329.

## Validation

- `python -m pytest tests/test_public_exports.py tests/test_hosted_errors.py tests/test_hosted_error_mapping.py` — 68 passed
- `git diff --check`

## AI assistance disclosure

This contribution was prepared with OpenAI Codex (GPT-5.6) and received a separate Sol/High review. The final diff and tests were independently verified before publication.