### PR TITLE
fix(ts-sdk): exclude markets missing resolutionDate in filterMarkets

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -3086,8 +3086,9 @@ export abstract class Exchange {
             }
 
             // ResolutionDate filter
-            if (criteria.resolutionDate && market.resolutionDate) {
+            if (criteria.resolutionDate) {
                 const resDate = market.resolutionDate;
+                if (!resDate) return false;
                 if (criteria.resolutionDate.before && resDate >= criteria.resolutionDate.before) {
                     return false;
                 }


### PR DESCRIPTION
## Summary

Fixes #1969.

When `filterMarkets` is called with a `resolutionDate` criterion, markets that have no `resolutionDate` set were incorrectly included in the TypeScript SDK. Core and the Python SDK already exclude them (`if (!resDate) return false` / `if not val: continue`).

This change mirrors that behavior in `sdks/typescript/pmxt/client.ts`.

## How to test

- Call `filterMarkets(markets, { resolutionDate: { before: someDate } })` with a mix of markets that have and lack `resolutionDate`.
- Markets without `resolutionDate` should be absent from the result (same as core / Python).

## Checklist

- [x] Matches core `BaseExchange.filterMarkets` resolutionDate handling
- [x] No dependency or generated-spec changes required
