### PR TITLE
fix(ts-sdk): add missing fee field to UserTrade (#1983)

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -236,6 +236,9 @@ export interface UserTrade {
     /** Market ID */
     marketId?: string;
 
+    /** Trading fee paid by the user for this fill, when the venue exposes it. */
+    fee?: number;
+
     /** On-chain transaction hash (populated in hosted mode when the trade was settled on-chain). */
     txHash?: string | null;
 


### PR DESCRIPTION
The core engine (`core/src/types.ts:215`) and the Python SDK
(`sdks/python/pmxt/models.py:404`) both expose `UserTrade.fee`, and the
generated `sdks/typescript/API_REFERENCE.md:1804` already documents it -- only
the TypeScript interface was missing it.

The value already arrives at runtime, since `convertUserTrade()` spreads the raw
response, so TypeScript users could not reach a field that was in fact present.
Hyperliquid populates it today (`core/src/exchanges/hyperliquid/normalizer.ts`).

Placed between `marketId` and `txHash` to match the field order in core and the
Python SDK.

## Testing

- `npm test --workspace=pmxtjs` 17/17 suites, 93 tests pass.
- `npx tsc --noEmit` clean.
- No codegen drift: `generate:docs`, `generate:openapi` and
  `generate-client-methods.js` all produce a byte-identical tree.
  (`models.ts` is hand-written, not generated.)

Closes #1983