### PR TITLE
fix(ts-sdk): exclude null price changes from filters

### DIFF
--- a/sdks/typescript/pmxt/client.ts
+++ b/sdks/typescript/pmxt/client.ts
@@ -3112,7 +3112,7 @@ export abstract class Exchange {
             // Price change filter
             if (criteria.priceChange24h) {
                 const outcome = market[criteria.priceChange24h.outcome];
-                if (!outcome || outcome.priceChange24h === undefined) return false;
+                if (!outcome || outcome.priceChange24h == null) return false;
 
                 if (criteria.priceChange24h.min !== undefined && outcome.priceChange24h < criteria.priceChange24h.min) {
                     return false;

--- a/sdks/typescript/tests/filter-markets-local.test.ts
+++ b/sdks/typescript/tests/filter-markets-local.test.ts
@@ -1,0 +1,31 @@
+import { Polymarket } from '../pmxt/client';
+
+describe('filterMarkets', () => {
+    it('filters out markets where priceChange24h is null while keeping zero', () => {
+        const client = new Polymarket({ autoStartServer: false });
+
+        const nullPriceChangeMarket: any = {
+            marketId: 'null-market',
+            title: 'Null market',
+            yes: { outcomeId: 'yes', outcome: 'Yes', label: 'Yes', price: 0.5, priceChange24h: null },
+            no: { outcomeId: 'no', outcome: 'No', label: 'No', price: 0.5, priceChange24h: null },
+        };
+
+        const zeroPriceChangeMarket: any = {
+            marketId: 'zero-market',
+            title: 'Zero market',
+            yes: { outcomeId: 'yes', outcome: 'Yes', label: 'Yes', price: 0.5, priceChange24h: 0 },
+            no: { outcomeId: 'no', outcome: 'No', label: 'No', price: 0.5, priceChange24h: 0.2 },
+        };
+
+        const out = client.filterMarkets([nullPriceChangeMarket, zeroPriceChangeMarket], {
+            priceChange24h: {
+                outcome: 'yes',
+                min: -1,
+            },
+        });
+
+        expect(out).toHaveLength(1);
+        expect(out[0].marketId).toBe('zero-market');
+    });
+});


### PR DESCRIPTION
## Summary

- Exclude an explicit `null` `priceChange24h` from price-change filters.
- Preserve numeric zero values and add a regression test for the distinction.

## Test plan

- `npm test --workspace=pmxtjs -- --runInBand tests/filter-markets-local.test.ts`
- `npm test --workspace=pmxtjs -- --runInBand`
- `npm run build --workspace=pmxtjs`
- `git diff --check origin/main...HEAD`

Fixes #1524
