### PR TITLE
fix(typescript): export OutcomeType alias

### DIFF
--- a/sdks/typescript/pmxt/models.ts
+++ b/sdks/typescript/pmxt/models.ts
@@ -871,6 +871,9 @@ export interface UnifiedEvent {
 // Advanced Filtering Types
 // ----------------------------------------------------------------------------
 
+/** Supported outcome labels for binary and up/down markets. */
+export type OutcomeType = 'yes' | 'no' | 'up' | 'down';
+
 /**
  * Advanced criteria for filtering markets.
  * Supports text search, numeric ranges, dates, categories, and price filters.
@@ -908,14 +911,14 @@ export interface MarketFilterCriteria {
 
     /** Filter by outcome price (for binary markets) */
     price?: {
-        outcome: 'yes' | 'no' | 'up' | 'down';
+        outcome: OutcomeType;
         min?: number;
         max?: number;
     };
 
     /** Filter by 24-hour price change */
     priceChange24h?: {
-        outcome: 'yes' | 'no' | 'up' | 'down';
+        outcome: OutcomeType;
         min?: number;
         max?: number;
     };

--- a/sdks/typescript/tests/outcome-type.test.ts
+++ b/sdks/typescript/tests/outcome-type.test.ts
@@ -1,0 +1,14 @@
+import type { MarketFilterCriteria, OutcomeType } from "../pmxt/models";
+
+describe("OutcomeType", () => {
+  it("is exported for reuse in market filters", () => {
+    const outcome: OutcomeType = "yes";
+    const criteria: MarketFilterCriteria = {
+      price: { outcome },
+      priceChange24h: { outcome },
+    };
+
+    expect(criteria.price?.outcome).toBe("yes");
+    expect(criteria.priceChange24h?.outcome).toBe("yes");
+  });
+});


### PR DESCRIPTION
Fixes #2075

## Summary
- export a reusable TypeScript `OutcomeType` alias matching the Python SDK
- use the alias for both market outcome filter fields
- add a focused test covering the public type export and filter compatibility

## Testing
- `npm --workspace=pmxtjs test -- --runInBand` (94 passed)
- `npm --workspace=pmxtjs run build`