### PR TITLE
fix(python): remove unused server port cache

### DIFF
--- a/sdks/python/pmxt/server_manager.py
+++ b/sdks/python/pmxt/server_manager.py
@@ -62,17 +62,7 @@ class ServerManager:
         """
         self.base_url = base_url
         self.lock_path = Path.home() / '.pmxt' / 'server.lock'
-        self._port = self._extract_port_from_url(base_url)
-    
-    def _extract_port_from_url(self, url: str) -> int:
-        """Extract port number from URL."""
-        try:
-            from urllib.parse import urlparse
-            parsed = urlparse(url)
-            return parsed.port or self.DEFAULT_PORT
-        except (ValueError, AttributeError):
-            return self.DEFAULT_PORT
-    
+
     def ensure_server_running(self) -> None:
         """
         Ensure the PMXT server is running.


### PR DESCRIPTION
Fixes #1706

Removes the unused `ServerManager._port` cache and its now-dead URL parsing helper. Runtime port discovery continues to use the lock file as the authoritative source.

Tests:
- `pytest -q tests/test_server_manager.py` with the generated package from the released wheel on `PYTHONPATH` (2 passed)
- `python -m py_compile sdks/python/pmxt/server_manager.py`
- `git diff --check`
