### PR TITLE
fix(typescript): remove unused router import

### DIFF
--- a/sdks/typescript/pmxt/router.ts
+++ b/sdks/typescript/pmxt/router.ts
@@ -13,7 +13,6 @@ import {
     EventMatchResult,
     FetchMatchedEventClustersParams,
     FetchMatchedMarketClustersParams,
-    MatchedMarketClusterParams,
     MatchedEventCluster,
     MatchedMarketCluster,
     PriceComparison,


### PR DESCRIPTION
## Summary

- remove the unused `MatchedMarketClusterParams` import from the TypeScript router
- eliminate the dead SDK import identified by the cross-language drift audit

## Tests

- `npm run build --workspace=pmxtjs`
- `npm test --workspace=pmxtjs -- --runInBand` (17 suites, 93 tests passed)

Fixes #1834
