### PR TITLE
fix(gemini-titan): use millisecond nonce for WebSocket authentication

### DIFF
--- a/core/src/exchanges/gemini-titan/auth.ts
+++ b/core/src/exchanges/gemini-titan/auth.ts
@@ -63,11 +63,11 @@ export class GeminiAuth {
     /**
      * Build WebSocket handshake authentication headers.
      *
-     * WebSocket auth uses a time-based nonce (seconds since epoch)
+     * WebSocket auth uses a time-based nonce (milliseconds since epoch)
      * as the payload, not a JSON object.
      */
     buildWsHeaders(): Record<string, string> {
-        const nonce = Math.floor(Date.now() / 1000).toString();
+        const nonce = Date.now().toString();
         const b64Payload = Buffer.from(nonce).toString('base64');
         const signature = crypto
             .createHmac('sha384', this.apiSecret)

--- a/core/test/exchanges/gemini-titan-auth.test.ts
+++ b/core/test/exchanges/gemini-titan-auth.test.ts
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+import { GeminiAuth } from '../../src/exchanges/gemini-titan/auth';
+
+// Milliseconds matter here: Gemini's WebSocket API requires the handshake
+// nonce to be a Unix timestamp in milliseconds.
+const FROZEN_NOW_MS = 1755878400000; // 2025-08-22T16:00:00.000Z
+
+describe('GeminiAuth WebSocket headers', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('uses a millisecond nonce for the WebSocket handshake', () => {
+        jest.spyOn(Date, 'now').mockReturnValue(FROZEN_NOW_MS);
+        const auth = new GeminiAuth({ apiKey: 'test-key', apiSecret: 'test-secret' });
+
+        const headers = auth.buildWsHeaders();
+
+        expect(headers['X-GEMINI-NONCE']).toBe(String(FROZEN_NOW_MS));
+    });
+
+    it('signs the same millisecond nonce it sends', () => {
+        jest.spyOn(Date, 'now').mockReturnValue(FROZEN_NOW_MS);
+        const auth = new GeminiAuth({ apiKey: 'test-key', apiSecret: 'test-secret' });
+
+        const headers = auth.buildWsHeaders();
+
+        const payload = Buffer.from(headers['X-GEMINI-PAYLOAD'], 'base64').toString('utf8');
+        expect(payload).toBe(String(FROZEN_NOW_MS));
+
+        const expectedSignature = crypto
+            .createHmac('sha384', 'test-secret')
+            .update(headers['X-GEMINI-PAYLOAD'])
+            .digest('hex');
+        expect(headers['X-GEMINI-SIGNATURE']).toBe(expectedSignature);
+    });
+});


### PR DESCRIPTION
Fixes #1933

## What was broken

buildWsHeaders() in core/src/exchanges/gemini-titan/auth.ts computed the WebSocket handshake nonce as Math.floor(Date.now() / 1000), sending seconds where Gemini's WebSocket API requires a millisecond Unix timestamp. The signed payload carried the same seconds value, so authenticated handshakes landed outside the server's replay-prevention window and were rejected, breaking watchOrderBook/watchTrades before any subscription could start.

The REST path was already correct: fetcher.ts signs payloads with GeminiAuth.nonce(), which returns milliseconds. Only buildWsHeaders() computed a nonce inline with the wrong unit.

## What changed

- Removed the /1000 division so the handshake nonce is Date.now() directly.
- Updated the doc comment above it that still said seconds since epoch.
- Added core/test/exchanges/gemini-titan-auth.test.ts, which freezes Date.now() and asserts both the X-GEMINI-NONCE header and the base64-decoded X-GEMINI-PAYLOAD carry the frozen millisecond value, plus an HMAC cross-check of X-GEMINI-SIGNATURE.

## Verification

- New tests fail on main (received 1755878400 vs expected 1755878400000) and pass with the patch.
- npx jest -c jest.config.js test/exchanges from core/: 11 suites, 34 tests, all passing.
- Full core jest: 823 passed; the only failure is the pre-existing pmxt-ensure-server sandbox case.
- bash scripts/verify-all.sh on this branch matches a clean checkout of main exactly: the only failures are the three known Windows-only HOME-vs-USERPROFILE sandbox defects (core test/server/pmxt-ensure-server.test.ts plus two sdks/python/tests/test_server_manager.py cases), which pass on ubuntu-latest CI.