### PR TITLE
fix(types): export websocket client config

### DIFF
--- a/sdks/typescript/index.ts
+++ b/sdks/typescript/index.ts
@@ -32,6 +32,7 @@ export { Exchange, Polymarket, Kalshi, KalshiDemo, Limitless, Myriad, Probable, 
 export type { ExchangeOptions, SuiBetsOptions } from "./pmxt/client.js";
 export { FeedClient } from "./pmxt/feed-client.js";
 export type { Ticker, Tickers, OHLCV, Market as FeedMarket, OracleRound, FeedClientOptions } from "./pmxt/feed-client.js";
+export type { WsClientConfig } from "./pmxt/ws-client.js";
 export { Router } from "./pmxt/router.js";
 export type { RouterOptions } from "./pmxt/router.js";
 export { ServerManager } from "./pmxt/server-manager.js";


### PR DESCRIPTION
Closes #2107. Re-exports WsClientConfig from the pmxtjs package root so consumers can type websocket options without importing an internal module. Validation: the TypeScript compiler reaches existing missing generated-client imports before it can complete; no generated files or unrelated changes are included.