### PR TITLE
Closes #2197: SDK drift: Python's `SIX_DEC_SCALE` in `_hosted_mappers.py` lacks the underscore-private naming its TypeScript counterpart and its own Python sibling use

### DIFF
--- a/sdks/python/pmxt/_hosted_mappers.py
+++ b/sdks/python/pmxt/_hosted_mappers.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping, TypeVar
 from .errors import InvalidOrder
 from .models import Balance, BuiltOrder, Order, Position, UserTrade
 
-SIX_DEC_SCALE = 1_000_000
+_SIX_DEC_SCALE = 1_000_000
 
 _T = TypeVar("_T")
 
@@ -23,7 +23,7 @@ _T = TypeVar("_T")
 def to_6dec(amount: float | str | Decimal) -> int:
     """Convert a decimal amount to integer micro-units with no rounding."""
     d = Decimal(str(amount))
-    scaled = d * SIX_DEC_SCALE
+    scaled = d * _SIX_DEC_SCALE
     if scaled != scaled.to_integral_value():
         raise InvalidOrder(f"amount precision exceeds 6 decimals: {amount!r}")
     return int(scaled)

--- a/sdks/python/tests/test_hosted_mappers.py
+++ b/sdks/python/tests/test_hosted_mappers.py
@@ -29,6 +29,11 @@ map_user_trade_v0 = _mapper(
 to_6dec = _hosted_mappers.to_6dec
 
 
+def test_six_decimal_scale_is_module_private():
+    assert not hasattr(_hosted_mappers, "SIX_DEC_SCALE")
+    assert _hosted_mappers._SIX_DEC_SCALE == 1_000_000
+
+
 def _iso_ms(value: str) -> int:
     return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
 


### PR DESCRIPTION
Closes #2197.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_wqwPNs6-dxYS0KMY5sFosg -->