### PR TITLE
docs: clarify hosted trading OpenAPI metadata

### DIFF
--- a/docs/api-reference/openapi-hosted-trading.json
+++ b/docs/api-reference/openapi-hosted-trading.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "PMXT Hosted Router API",
-    "description": "Hosted-only endpoints for cross-venue search, matching, arbitrage, and SQL.",
+    "title": "PMXT Hosted Trading API",
+    "description": "Hosted-only endpoints for building, submitting, canceling, and reading trades, orders, balances, and positions.",
     "version": "49fbcd4"
   },
   "servers": [


### PR DESCRIPTION
## Summary

- update the hosted trading OpenAPI `info.title` so it is distinguishable from the hosted router spec
- replace the copied search/matching/arbitrage/SQL description with trading/order/balance/position wording

Fixes #2212

## Verification

- `python3 - <<'PY' ...` parsed both hosted OpenAPI specs, asserted the hosted-trading info block no longer mentions search/SQL, and confirmed all hosted-trading paths are trade/order/user endpoints
