### PR TITLE
Closes #2212: openapi-hosted-trading.json's info block is copy-pasted from openapi-hosted.json — claims "search, matching, arbitrage, and SQL" for a trade-only spec

### DIFF
--- a/docs/api-reference/openapi-hosted-trading.json
+++ b/docs/api-reference/openapi-hosted-trading.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "PMXT Hosted Router API",
-    "description": "Hosted-only endpoints for cross-venue search, matching, arbitrage, and SQL.",
+    "title": "PMXT Hosted Trading API",
+    "description": "Hosted-only endpoints for trading, orders, balances, positions, and fills.",
     "version": "49fbcd4"
   },
   "servers": [


### PR DESCRIPTION
Closes #2212.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_VxEH1CTdpp3jD1Ck7uIifA -->